### PR TITLE
Added support for Advanced Stats and Technical Indicators

### DIFF
--- a/IEXSharp/Model/Stock/Response/AdvancedStatsResponse.cs
+++ b/IEXSharp/Model/Stock/Response/AdvancedStatsResponse.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace VSLee.IEXSharp.Model.Stock.Response
+{
+	public class AdvancedStatsResponse : KeyStatsResponse
+	{
+		public decimal beta { get; set; }
+		public long totalCash { get; set; }
+		public long currentDebt { get; set; }
+		public long revenue { get; set; }
+		public long grossProfit { get; set; }
+		public long totalRevenue { get; set; }
+		public long ebitda { get; set; }
+		public decimal revenuePerShare { get; set; }
+		public decimal revenuePerEmployee { get; set; }
+		public decimal debtToEquity { get; set; }
+		public decimal profitMargin { get; set; }
+		public long enterpriseValue { get; set; }
+		public decimal enterpriseValueToRevenue { get; set; }
+		public decimal priceToSales { get; set; }
+		public decimal priceToBook { get; set; }
+		public decimal forwardPERatio { get; set; }
+		public decimal pegRatio { get; set; }
+		public decimal peHigh { get; set; }
+		public decimal peLow { get; set; }
+		public DateTime? week52highDate { get; set; }
+		public DateTime? week52lowDate { get; set; }
+		public decimal putCallRatio { get; set; }
+	}
+}

--- a/IEXSharp/Model/Stock/Response/KeyStatsResponse.cs
+++ b/IEXSharp/Model/Stock/Response/KeyStatsResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace VSLee.IEXSharp.Model.Stock.Response
+﻿using System;
+
+namespace VSLee.IEXSharp.Model.Stock.Response
 {
 	public class KeyStatsResponse
 	{
@@ -18,9 +20,9 @@
 		public decimal ttmEPS { get; set; }
 		public decimal ttmDividendRate { get; set; }
 		public decimal dividendYield { get; set; }
-		public string nextDividendDate { get; set; }
-		public string exDividendDate { get; set; }
-		public string nextEarningsDate { get; set; }
+		public DateTime? nextDividendDate { get; set; }
+		public DateTime? exDividendDate { get; set; }
+		public DateTime? nextEarningsDate { get; set; }
 		public long peRatio { get; set; }
 		public decimal maxChangePercent { get; set; }
 		public decimal year5ChangePercent { get; set; }

--- a/IEXSharp/Model/Stock/Response/TechnicalIndicatorResponse.cs
+++ b/IEXSharp/Model/Stock/Response/TechnicalIndicatorResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace VSLee.IEXSharp.Model.Stock.Response
+{
+	public class TechnicalIndicatorsResponse
+	{
+		public IEnumerable<string> indicator { get; set; }
+		public IEnumerable<Dictionary<string, string>> chart { get; set; }
+	}
+}

--- a/IEXSharp/Service/V2/Stock/IStockService.cs
+++ b/IEXSharp/Service/V2/Stock/IStockService.cs
@@ -348,6 +348,14 @@ namespace VSLee.IEXSharp.Service.V2.Stock
 		Task<IEXResponse<PriceTargetResponse>> PriceTargetAsync(string symbol);
 
 		/// <summary>
+		/// <see cref="https://iexcloud.io/docs/api/#technical-indicators"/>
+		/// </summary>
+		/// <param name="symbol"></param>
+		/// <param name="indicator"></param>
+		/// <returns></returns>
+		Task<IEXResponse<TechnicalIndicatorsResponse>> TechnicalIndicatorsAsync(string symbol, string indicator);
+
+		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#quote"/>
 		/// </summary>
 		/// <param name="symbol"></param>

--- a/IEXSharp/Service/V2/Stock/IStockService.cs
+++ b/IEXSharp/Service/V2/Stock/IStockService.cs
@@ -363,6 +363,13 @@ namespace VSLee.IEXSharp.Service.V2.Stock
 		Task<IEXResponse<string>> QuoteFieldAsync(string symbol, string field);
 
 		/// <summary>
+		/// <see cref="https://iexcloud.io/docs/api/#advanced-stats"/>
+		/// </summary>
+		/// <param name="symbol"></param>
+		/// <returns></returns>
+		Task<IEXResponse<AdvancedStatsResponse>> AdvancedStatsAsync(string symbol);
+
+		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#recommendation-trends"/>
 		/// </summary>
 		/// <param name="symbol"></param>

--- a/IEXSharp/Service/V2/Stock/StockService.cs
+++ b/IEXSharp/Service/V2/Stock/StockService.cs
@@ -411,6 +411,9 @@ namespace VSLee.IEXSharp.Service.V2.Stock
 			return await executor.ExecuteAsync<string>(urlPattern, pathNvc, qsb);
 		}
 
+		public async Task<IEXResponse<AdvancedStatsResponse>> AdvancedStatsAsync(string symbol) =>
+			await executor.SymbolExecuteAsync<AdvancedStatsResponse>("stock/[symbol]/advanced-stats", symbol);
+
 		public async Task<IEXResponse<IEnumerable<RecommendationTrendResponse>>> RecommendationTrendAsync(string symbol) =>
 			await executor.SymbolExecuteAsync<IEnumerable<RecommendationTrendResponse>>(
 				"stock/[symbol]/recommendation-trends", symbol);

--- a/IEXSharp/Service/V2/Stock/StockService.cs
+++ b/IEXSharp/Service/V2/Stock/StockService.cs
@@ -397,6 +397,9 @@ namespace VSLee.IEXSharp.Service.V2.Stock
 		public async Task<IEXResponse<PriceTargetResponse>> PriceTargetAsync(string symbol) =>
 			await executor.SymbolExecuteAsync<PriceTargetResponse>("stock/[symbol]/price-target", symbol);
 
+		public async Task<IEXResponse<TechnicalIndicatorsResponse>> TechnicalIndicatorsAsync(string symbol, string indicator) =>
+			await executor.SymbolExecuteAsync<TechnicalIndicatorsResponse>($"stock/[symbol]/indicator/{indicator}", symbol);
+
 		public async Task<IEXResponse<Quote>> QuoteAsync(string symbol) =>
 			await executor.SymbolExecuteAsync<Quote>("stock/[symbol]/quote", symbol);
 

--- a/IEXSharpTest/Cloud(V2)/StockTest.cs
+++ b/IEXSharpTest/Cloud(V2)/StockTest.cs
@@ -645,6 +645,17 @@ namespace VSLee.IEXSharpTest.Cloud
 		}
 
 		[Test]
+		[TestCase("AAPL", "adxr")]
+		[TestCase("FB", "abs")]
+		public async Task TechnicalIndicatorsAsyncTest(string symbol, string indicator)
+		{
+			var response = await sandBoxClient.Stock.TechnicalIndicatorsAsync(symbol, indicator);
+
+			Assert.IsNull(response.ErrorMessage);
+			Assert.IsNotNull(response.Data);
+		}
+
+		[Test]
 		public async Task SectorPerformanceAsync()
 		{
 			var response = await sandBoxClient.Stock.SectorPerformanceAsync();

--- a/IEXSharpTest/Cloud(V2)/StockTest.cs
+++ b/IEXSharpTest/Cloud(V2)/StockTest.cs
@@ -621,6 +621,20 @@ namespace VSLee.IEXSharpTest.Cloud
 		[Test]
 		[TestCase("AAPL")]
 		[TestCase("FB")]
+		public async Task AdvancedStatsAsyncTest(string symbol)
+		{
+			var response = await sandBoxClient.Stock.AdvancedStatsAsync(symbol);
+
+			Assert.IsNull(response.ErrorMessage);
+			Assert.IsNotNull(response.Data);
+
+			Assert.NotNull(response.Data.marketcap);
+			Assert.NotNull(response.Data.beta);
+		}
+
+		[Test]
+		[TestCase("AAPL")]
+		[TestCase("FB")]
 		public async Task RecommandationTrendAsyncTest(string symbol)
 		{
 			var response = await sandBoxClient.Stock.RecommendationTrendAsync(symbol);


### PR DESCRIPTION
Added support for: 
- https://iexcloud.io/docs/api/#advanced-stats
- https://iexcloud.io/docs/api/#technical-indicators

It might be worth considering rearranging services into the groupings that they're in in the documentation. 

The Stock Service is getting quite large and encompasses Stock, Stock Research, Reference Data and Market Info.