### PR TITLE
Adding additional Forex/Currencies endpoints

### DIFF
--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -1,7 +1,6 @@
 using IEXSharp.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net.Http;
@@ -132,6 +131,20 @@ namespace VSLee.IEXSharp.Helper
 			var pathNvc = new NameValueCollection { { "symbol", symbol }, { "last", last.ToString() }, { "field", field } };
 
 			return await ExecuteAsync<string>(urlPattern, pathNvc, qsb);
+		}
+
+		public async Task<IEXResponse<ReturnType>> QueryStringExecuteAsync<ReturnType>(string url, Dictionary<string, string> queryParameters)
+			where ReturnType : class
+		{
+			var qsb = new QueryStringBuilder();
+			var pathNVC = new NameValueCollection();
+
+			foreach (KeyValuePair<string, string> entry in queryParameters)
+			{
+				qsb.Add(entry.Key, entry.Value);
+			}
+
+			return await ExecuteAsync<ReturnType>(url, pathNVC, qsb);
 		}
 	}
 }

--- a/IEXSharp/Model/ForexCurrencies/Response/CurrencyConvertResponse.cs
+++ b/IEXSharp/Model/ForexCurrencies/Response/CurrencyConvertResponse.cs
@@ -1,0 +1,7 @@
+namespace VSLee.IEXSharp.Model.ForexCurrencies.Response
+{
+	public class CurrencyConvertResponse : CurrencyRateResponse
+	{
+		public decimal amount { get; set; }
+	}
+}

--- a/IEXSharp/Model/ForexCurrencies/Response/CurrencyHistoricalRateResponse.cs
+++ b/IEXSharp/Model/ForexCurrencies/Response/CurrencyHistoricalRateResponse.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace VSLee.IEXSharp.Model.ForexCurrencies.Response
+{
+	public class CurrencyHistoricalRateResponse : CurrencyRateResponse
+	{
+		public DateTime? date { get; set; }
+	}
+}

--- a/IEXSharp/Model/ForexCurrencies/Response/CurrencyRateResponse.cs
+++ b/IEXSharp/Model/ForexCurrencies/Response/CurrencyRateResponse.cs
@@ -1,0 +1,9 @@
+namespace VSLee.IEXSharp.Model.ForexCurrencies.Response
+{
+	public class CurrencyRateResponse
+	{
+		public string symbol { get; set; }
+		public decimal rate { get; set; }
+		public long timestamp { get; set; }
+	}
+}

--- a/IEXSharp/Service/V2/Crypto/ICryptoService.cs
+++ b/IEXSharp/Service/V2/Crypto/ICryptoService.cs
@@ -10,7 +10,6 @@ namespace VSLee.IEXSharp.Service.V2.Crypto
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#cryptocurrency-book"/>
 		/// </summary>
-		/// <value>700</value>
 		/// <returns></returns>
 		Task<IEXResponse<CryptoBookResponse>> BookAsync(string symbol);
 

--- a/IEXSharp/Service/V2/ForexCurrencies/ForexCurrenciesService.cs
+++ b/IEXSharp/Service/V2/ForexCurrencies/ForexCurrenciesService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using VSLee.IEXSharp.Helper;
 using VSLee.IEXSharp.Model.ForexCurrencies.Response;
 using System.Collections.Specialized;
@@ -9,11 +10,32 @@ namespace VSLee.IEXSharp.Service.V2.ForexCurrencies
 {
 	internal class ForexCurrenciesService : IForexCurrenciesService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
 		public ForexCurrenciesService(HttpClient client, string sk, string pk, bool sign)
 		{
-			_executor = new ExecutorREST(client, sk, pk, sign);
+			executor = new ExecutorREST(client, sk, pk, sign);
+		}
+
+		public async Task<IEXResponse<IEnumerable<CurrencyRateResponse>>> LatestRatesAsync(string symbols)
+		{
+			var queryParameterDictionary = new Dictionary<string, string> {{"symbols", symbols}};
+
+			return await executor.QueryStringExecuteAsync<IEnumerable<CurrencyRateResponse>>($"fx/latest", queryParameterDictionary);
+		}
+
+		public async Task<IEXResponse<IEnumerable<CurrencyConvertResponse>>> ConvertAsync(string symbols, string amount)
+		{
+			var queryParameterDictionary = new Dictionary<string, string> {{"symbols", symbols}, {"amount", amount}};
+
+			return await executor.QueryStringExecuteAsync<IEnumerable<CurrencyConvertResponse>>($"fx/convert", queryParameterDictionary);
+		}
+
+		public async Task<IEXResponse<IEnumerable<IEnumerable<CurrencyHistoricalRateResponse>>>> HistoricalDailyAsync(string symbols, string query, string queryValue)
+		{
+			var queryParameterDictionary = new Dictionary<string, string> {{"symbols", symbols}, {query, queryValue}};
+
+			return await executor.QueryStringExecuteAsync<IEnumerable<IEnumerable<CurrencyHistoricalRateResponse>>>($"fx/historical", queryParameterDictionary);
 		}
 
 		public async Task<IEXResponse<ExchangeRateResponse>> ExchangeRateAsync(string from, string to)
@@ -24,7 +46,7 @@ namespace VSLee.IEXSharp.Service.V2.ForexCurrencies
 
 			var pathNvc = new NameValueCollection { { "from", from }, { "to", to } };
 
-			return await _executor.ExecuteAsync<ExchangeRateResponse>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<ExchangeRateResponse>(urlPattern, pathNvc, qsb);
 		}
 	}
 }

--- a/IEXSharp/Service/V2/ForexCurrencies/IForexCurrenciesService.cs
+++ b/IEXSharp/Service/V2/ForexCurrencies/IForexCurrenciesService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using IEXSharp.Model;
 using System.Threading.Tasks;
 using VSLee.IEXSharp.Model.ForexCurrencies.Response;
@@ -13,5 +14,26 @@ namespace VSLee.IEXSharp.Service.V2.ForexCurrencies
 		/// <param name="to"></param>
 		/// <returns></returns>
 		Task<IEXResponse<ExchangeRateResponse>> ExchangeRateAsync(string from, string to);
+
+		/// <summary>
+		/// <see cref="https://iexcloud.io/docs/api/#latest-currency-rates"/>
+		/// </summary>
+		/// <value>700</value>
+		/// <returns></returns>
+		Task<IEXResponse<IEnumerable<CurrencyRateResponse>>> LatestRatesAsync(string symbols);
+
+		/// <summary>
+		/// <see cref="https://iexcloud.io/docs/api/#currency-conversion"/>
+		/// </summary>
+		/// <value>700</value>
+		/// <returns></returns>
+		Task<IEXResponse<IEnumerable<CurrencyConvertResponse>>> ConvertAsync(string symbols, string amount);
+
+		/// <summary>
+		/// <see cref="https://iexcloud.io/docs/api/#historical-daily"/>
+		/// </summary>
+		/// <value>700</value>
+		/// <returns></returns>
+		Task<IEXResponse<IEnumerable<IEnumerable<CurrencyHistoricalRateResponse>>>> HistoricalDailyAsync(string symbols, string query, string queryValue);
 	}
 }

--- a/IEXSharp/Service/V2/ForexCurrencies/IForexCurrenciesService.cs
+++ b/IEXSharp/Service/V2/ForexCurrencies/IForexCurrenciesService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Data;
 using IEXSharp.Model;
 using System.Threading.Tasks;
 using VSLee.IEXSharp.Model.ForexCurrencies.Response;
@@ -18,21 +19,24 @@ namespace VSLee.IEXSharp.Service.V2.ForexCurrencies
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#latest-currency-rates"/>
 		/// </summary>
-		/// <value>700</value>
+		/// <param name="symbols"></param>
 		/// <returns></returns>
 		Task<IEXResponse<IEnumerable<CurrencyRateResponse>>> LatestRatesAsync(string symbols);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#currency-conversion"/>
 		/// </summary>
-		/// <value>700</value>
+		/// <param name="symbols"></param>
+		/// <param name="amount"></param>
 		/// <returns></returns>
 		Task<IEXResponse<IEnumerable<CurrencyConvertResponse>>> ConvertAsync(string symbols, string amount);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#historical-daily"/>
 		/// </summary>
-		/// <value>700</value>
+		/// <param name="symbols"></param>
+		/// <param name="query"></param>
+		/// /// <param name="queryValue"></param>
 		/// <returns></returns>
 		Task<IEXResponse<IEnumerable<IEnumerable<CurrencyHistoricalRateResponse>>>> HistoricalDailyAsync(string symbols, string query, string queryValue);
 	}

--- a/IEXSharpTest/Cloud(V2)/ForexCurrenciesTest.cs
+++ b/IEXSharpTest/Cloud(V2)/ForexCurrenciesTest.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using VSLee.IEXSharp;
@@ -17,12 +18,54 @@ namespace VSLee.IEXSharpTest.Cloud
 		// Not supported for free account
 		[Test]
 		[TestCase("EUR", "USD")]
-		public async Task ExchangeRateAsync(string from, string to)
+		public async Task ExchangeRateAsyncTest(string from, string to)
 		{
 			var response = await sandBoxClient.ForexCurrencies.ExchangeRateAsync(from, to);
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
+		}
+
+		[Test]
+		[TestCase("USDCAD")]
+		[TestCase("USDCAD,USDGBP,USDJPY")]
+		public async Task LatestRatesAsyncTest(string symbols)
+		{
+			var response = await sandBoxClient.ForexCurrencies.LatestRatesAsync(symbols);
+
+			Assert.IsNull(response.ErrorMessage);
+			Assert.IsNotNull(response.Data);
+
+			Assert.IsNotNull(response.Data.First().symbol);
+			Assert.IsNotNull(response.Data.First().timestamp);
+		}
+
+		[Test]
+		[TestCase("USDGBP", "99.00")]
+		[TestCase("USDCAD,USDGBP,USDJPY", "7500.00")]
+		public async Task ConvertAsyncTest(string symbols, string amount)
+		{
+			var response = await sandBoxClient.ForexCurrencies.ConvertAsync(symbols, amount);
+
+			Assert.IsNull(response.ErrorMessage);
+			Assert.IsNotNull(response.Data);
+
+			Assert.IsNotNull(response.Data.First().symbol);
+			Assert.IsNotNull(response.Data.First().amount);
+		}
+
+		[Test]
+		[TestCase("USDGBP", "last", "3")]
+		[TestCase("USDCAD,USDGBP,USDJPY", "first", "5")]
+		public async Task HistoricalDailyAsyncTest(string symbols, string query, string queryValue)
+		{
+			var response = await sandBoxClient.ForexCurrencies.HistoricalDailyAsync(symbols, query, queryValue);
+
+			Assert.IsNull(response.ErrorMessage);
+			Assert.IsNotNull(response.Data);
+
+			Assert.IsNotNull(response.Data.First().First().rate);
+			Assert.IsNotNull(response.Data.First().First().date);
 		}
 	}
 }


### PR DESCRIPTION
Added Support for:

- https://iexcloud.io/docs/api/#latest-currency-rates
- https://iexcloud.io/docs/api/#currency-conversion
- https://iexcloud.io/docs/api/#historical-daily

And an executor to handle query strings. 