### PR TITLE
Preventitive measures for thread blocking

### DIFF
--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -15,7 +15,7 @@ namespace VSLee.IEXSharp.Helper
 		private readonly bool sign;
 		private readonly JsonSerializerSettings jsonSerializerSettings;
 
-		public ExecutorREST(HttpClient client, string secretToken, string publishableToken, bool sign) : base(publishableToken: publishableToken, secretToken: secretToken)
+		public ExecutorREST(HttpClient client, string secretToken, string publishableToken, bool sign) : base(publishableToken, secretToken)
 		{
 			this.client = client;
 			if (sign)
@@ -89,7 +89,7 @@ namespace VSLee.IEXSharp.Helper
 			var qsb = new QueryStringBuilder();
 			var pathNVC = new NameValueCollection();
 
-			return await ExecuteAsync<ReturnType>(url, pathNVC, qsb);
+			return await ExecuteAsync<ReturnType>(url, pathNVC, qsb).ConfigureAwait(false);;
 		}
 
 		public async Task<IEXResponse<ReturnType>> SymbolExecuteAsync<ReturnType>(string urlPattern, string symbol)
@@ -98,7 +98,7 @@ namespace VSLee.IEXSharp.Helper
 			var qsb = new QueryStringBuilder();
 			var pathNvc = new NameValueCollection { { "symbol", symbol } };
 
-			return await ExecuteAsync<ReturnType>(urlPattern, pathNvc, qsb);
+			return await ExecuteAsync<ReturnType>(urlPattern, pathNvc, qsb).ConfigureAwait(false);;
 		}
 
 		public async Task<IEXResponse<ReturnType>> SymbolsExecuteAsync<ReturnType>(string urlPattern, IEnumerable<string> symbols)
@@ -109,7 +109,7 @@ namespace VSLee.IEXSharp.Helper
 
 			var pathNvc = new NameValueCollection();
 
-			return await ExecuteAsync<ReturnType>(urlPattern, pathNvc, qsb);
+			return await ExecuteAsync<ReturnType>(urlPattern, pathNvc, qsb).ConfigureAwait(false);;
 		}
 
 		public async Task<IEXResponse<ReturnType>> SymbolLastExecuteAsync<ReturnType>(string urlPattern, string symbol, int last)
@@ -118,7 +118,7 @@ namespace VSLee.IEXSharp.Helper
 			var qsb = new QueryStringBuilder();
 			var pathNvc = new NameValueCollection { { "symbol", symbol }, { "last", last.ToString() } };
 
-			return await ExecuteAsync<ReturnType>(urlPattern, pathNvc, qsb);
+			return await ExecuteAsync<ReturnType>(urlPattern, pathNvc, qsb).ConfigureAwait(false);;
 		}
 
 		public async Task<IEXResponse<string>> SymbolLastFieldExecuteAsync(string urlPattern, string symbol, string field, int last)
@@ -126,7 +126,7 @@ namespace VSLee.IEXSharp.Helper
 			var qsb = new QueryStringBuilder();
 			var pathNvc = new NameValueCollection { { "symbol", symbol }, { "last", last.ToString() }, { "field", field } };
 
-			return await ExecuteAsync<string>(urlPattern, pathNvc, qsb);
+			return await ExecuteAsync<string>(urlPattern, pathNvc, qsb).ConfigureAwait(false);;
 		}
 	}
 }


### PR DESCRIPTION
Adding .ConfigureAwait(false); to ExecuteAsync calls to prevent thread blocking.