### PR TITLE
Removed Effective Spread Endpoint

### DIFF
--- a/IEXSharp/Service/Cloud/Stock/IStockService.cs
+++ b/IEXSharp/Service/Cloud/Stock/IStockService.cs
@@ -33,13 +33,6 @@ namespace VSLee.IEXSharp.Service.Cloud.Stock
 		Task<IEXResponse<Dictionary<string, BatchResponse>>> BatchByMarketAsync(IEnumerable<string> symbols, IEnumerable<BatchType> types, string range = "", int last = 1);
 
 		/// <summary>
-		/// <see cref="https://iexcloud.io/docs/api/#effective-spread"/>
-		/// </summary>
-		/// <param name="symbol"></param>
-		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<EffectiveSpreadResponse>>> EffectiveSpreadAsync(string symbol);
-
-		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#news"/>
 		/// </summary>
 		/// <param name="symbol"></param>

--- a/IEXSharp/Service/Cloud/Stock/StockService.cs
+++ b/IEXSharp/Service/Cloud/Stock/StockService.cs
@@ -120,10 +120,6 @@ namespace VSLee.IEXSharp.Service.Cloud.Stock
 			return await executor.ExecuteAsync<Dictionary<string, BatchResponse>>(urlPattern, pathNvc, qsb);
 		}
 
-		public async Task<IEXResponse<IEnumerable<EffectiveSpreadResponse>>> EffectiveSpreadAsync(string symbol) =>
-			await executor.SymbolExecuteAsync<IEnumerable<EffectiveSpreadResponse>>(
-				"stock/[symbol]/effective-spread", symbol);
-
 		public async Task<IEXResponse<IEnumerable<NewsResponse>>> NewsAsync(string symbol, int last = 10) =>
 			await executor.SymbolLastExecuteAsync<IEnumerable<NewsResponse>>("stock/[symbol]/news/last/[last]", symbol, last);
 

--- a/IEXSharpTest/Cloud/StockPricesTest.cs
+++ b/IEXSharpTest/Cloud/StockPricesTest.cs
@@ -141,8 +141,8 @@ namespace VSLee.IEXSharpTest.Cloud
 		}
 
 		[Test]
-		[TestCase("AAPL")]
-		[TestCase("FB")]
+		[TestCase("F")]
+		[TestCase("GE")]
 		public async Task LargestTradesAsyncTest(string symbol)
 		{
 			var response = await sandBoxClient.StockPrices.LargestTradesAsync(symbol);

--- a/IEXSharpTest/Cloud/StockTest.cs
+++ b/IEXSharpTest/Cloud/StockTest.cs
@@ -44,18 +44,7 @@ namespace VSLee.IEXSharpTest.Cloud
 			Assert.IsNotNull(response);
 			Assert.IsNotNull(response.Data[symbols.ToList()[0]]);
 		}
-
-		[Test]
-		[TestCase("AAPL")]
-		[TestCase("FB")]
-		public async Task EffectiveSpreadAsyncTest(string symbol)
-		{
-			var response = await sandBoxClient.Stock.EffectiveSpreadAsync(symbol);
-
-			Assert.IsNull(response.ErrorMessage);
-			Assert.IsNotNull(response.Data);
-		}
-
+		
 		[Test]
 		[TestCase("AAPL", 10)]
 		[TestCase("FB", 20)]


### PR DESCRIPTION
Removed StockService.EffectiveSpreadAsync() as it seems to have been removed. https://iexcloud.io/docs/api/#effective-spread

LargestTradesAsyncTest now using stocks from the NYSE. 

See: https://iexcloud.io/docs/api/#largest-trades

For Nasdaq-listed stocks, this endpoint returns an empty array unless the account has been authorized by UTP to receive delayed market data on Nasdaq-listed stocks.