### PR TITLE
Tests, typos and restructuring

### DIFF
--- a/IEXSharp/Service/Cloud/InvestorsExchangeData/IInvestorsExchangeDataService.cs
+++ b/IEXSharp/Service/Cloud/InvestorsExchangeData/IInvestorsExchangeDataService.cs
@@ -20,7 +20,7 @@ namespace VSLee.IEXSharp.Service.Cloud.InvestorsExchangeData
 		/// </summary>
 		/// <param name="symbols"></param>
 		/// <returns></returns>
-		Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepActionAsync(IEnumerable<string> symbols);
+		Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepAuctionAsync(IEnumerable<string> symbols);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#deep-book"/>

--- a/IEXSharp/Service/Cloud/InvestorsExchangeData/InvestorsExchangeDataService.cs
+++ b/IEXSharp/Service/Cloud/InvestorsExchangeData/InvestorsExchangeDataService.cs
@@ -12,55 +12,55 @@ namespace VSLee.IEXSharp.Service.Cloud.InvestorsExchangeData
 {
 	internal class InvestorsExchangeDataService : IInvestorsExchangeDataService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
 		public InvestorsExchangeDataService(HttpClient client, string sk, string pk, bool sign)
 		{
-			_executor = new ExecutorREST(client, sk, pk, sign);
+			executor = new ExecutorREST(client, sk, pk, sign);
 		}
 
 		public async Task<IEXResponse<DeepResponse>> DeepAsync(IEnumerable<string> symbols)
-		   => await _executor.SymbolsExecuteAsync<DeepResponse>("deep", symbols);
+		   => await executor.SymbolsExecuteAsync<DeepResponse>("deep", symbols);
 
-		public async Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepActionAsync(IEnumerable<string> symbols)
-		  => await _executor.SymbolsExecuteAsync<Dictionary<string, DeepAuctionResponse>>("deep/auction", symbols);
+		public async Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepAuctionAsync(IEnumerable<string> symbols)
+		  => await executor.SymbolsExecuteAsync<Dictionary<string, DeepAuctionResponse>>("deep/auction", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepBookResponse>>> DeepBookAsync(IEnumerable<string> symbols)
-		   => await _executor.SymbolsExecuteAsync<Dictionary<string, DeepBookResponse>>("deep/book", symbols);
+		   => await executor.SymbolsExecuteAsync<Dictionary<string, DeepBookResponse>>("deep/book", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepOperationalHaltStatusResponse>>> DeepOperationHaltStatusAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepOperationalHaltStatusResponse>>("deep/op-halt-status", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepOperationalHaltStatusResponse>>("deep/op-halt-status", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepOfficialPriceResponse>>> DeepOfficialPriceAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepOfficialPriceResponse>>("deep/official-price", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepOfficialPriceResponse>>("deep/official-price", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepSecurityEventResponse>>> DeepSecurityEventAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepSecurityEventResponse>>("deep/security-event", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepSecurityEventResponse>>("deep/security-event", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepShortSalePriceTestStatusResponse>>> DeepShortSalePriceTestStatusAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepShortSalePriceTestStatusResponse>>("deep/ssr-status", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepShortSalePriceTestStatusResponse>>("deep/ssr-status", symbols);
 
 		public async Task<IEXResponse<DeepSystemEventResponse>> DeepSystemEventAsync()
-			=> await _executor.NoParamExecute<DeepSystemEventResponse>("deep/system-event");
+			=> await executor.NoParamExecute<DeepSystemEventResponse>("deep/system-event");
 
 		public async Task<IEXResponse<Dictionary<string, IEnumerable<DeepTradeResponse>>>> DeepTradeAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, IEnumerable<DeepTradeResponse>>>> DeepTradeBreaksAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades-breaks", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades-breaks", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepTradingStatusResponse>>> DeepTradingStatusAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepTradingStatusResponse>>("deep/trades-status", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepTradingStatusResponse>>("deep/trades-status", symbols);
 
 		public async Task<IEXResponse<IEnumerable<LastResponse>>> LastAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<IEnumerable<LastResponse>>("tops/last", symbols);
+			=> await executor.SymbolsExecuteAsync<IEnumerable<LastResponse>>("tops/last", symbols);
 
 		public async Task<IEXResponse<IEnumerable<ListedRegulationSHOThresholdSecuritiesListResponse>>> ListedRegulationSHOThresholdSecuritiesListAsync(string symbol)
-			=> await _executor.SymbolExecuteAsync<IEnumerable<ListedRegulationSHOThresholdSecuritiesListResponse>>(
+			=> await executor.SymbolExecuteAsync<IEnumerable<ListedRegulationSHOThresholdSecuritiesListResponse>>(
 				"stock/[symbol]/threshold-securities", symbol);
 
 		public async Task<IEXResponse<IEnumerable<ListedShortInterestListResponse>>> ListedShortInterestListAsync(string symbol)
-			=> await _executor.SymbolExecuteAsync<IEnumerable<ListedShortInterestListResponse>>(
+			=> await executor.SymbolExecuteAsync<IEnumerable<ListedShortInterestListResponse>>(
 				"stock/[symbol]/short-interest", symbol);
 
 		public async Task<IEXResponse<IEnumerable<StatsHisoricalDailyResponse>>> StatsHistoricalDailyByDateAsync(string date)
@@ -72,7 +72,7 @@ namespace VSLee.IEXSharp.Service.Cloud.InvestorsExchangeData
 
 			var pathNvc = new NameValueCollection();
 
-			return await _executor.ExecuteAsync<IEnumerable<StatsHisoricalDailyResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<StatsHisoricalDailyResponse>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<IEnumerable<StatsHisoricalDailyResponse>>> StatsHistoricalDailyByLastAsync(int last)
@@ -84,7 +84,7 @@ namespace VSLee.IEXSharp.Service.Cloud.InvestorsExchangeData
 
 			var pathNvc = new NameValueCollection();
 
-			return await _executor.ExecuteAsync<IEnumerable<StatsHisoricalDailyResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<StatsHisoricalDailyResponse>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<IEnumerable<StatsHistoricalSummaryResponse>>> StatsHistoricalSummaryAsync(DateTime? date = null)
@@ -96,25 +96,25 @@ namespace VSLee.IEXSharp.Service.Cloud.InvestorsExchangeData
 
 			var pathNvc = new NameValueCollection();
 
-			return await _executor.ExecuteAsync<IEnumerable<StatsHistoricalSummaryResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<StatsHistoricalSummaryResponse>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<StatsIntradayResponse>> StatsIntradayAsync()
-			=> await _executor.NoParamExecute<StatsIntradayResponse>("stats/intraday");
+			=> await executor.NoParamExecute<StatsIntradayResponse>("stats/intraday");
 
 		public async Task<IEXResponse<IEnumerable<StatsRecentResponse>>> StatsRecentAsync()
-			=> await _executor.NoParamExecute<IEnumerable<StatsRecentResponse>>("stats/recent");
+			=> await executor.NoParamExecute<IEnumerable<StatsRecentResponse>>("stats/recent");
 
 		public async Task<IEXResponse<StatsRecordResponse>> StatsRecordAsync()
-			=> await _executor.NoParamExecute<StatsRecordResponse>("stats/records");
+			=> await executor.NoParamExecute<StatsRecordResponse>("stats/records");
 
 		public async Task<IEXResponse<IEnumerable<TOPSResponse>>> TOPSAsync(IEnumerable<string> symbols)
 		{
 			if (symbols.Count() > 0)
 			{
-				return await _executor.SymbolsExecuteAsync<IEnumerable<TOPSResponse>>("tops", symbols);
+				return await executor.SymbolsExecuteAsync<IEnumerable<TOPSResponse>>("tops", symbols);
 			}
-			return await _executor.NoParamExecute<IEnumerable<TOPSResponse>>("tops");
+			return await executor.NoParamExecute<IEnumerable<TOPSResponse>>("tops");
 		}
 	}
 }

--- a/IEXSharp/Service/Legacy/Market/IMarketService.cs
+++ b/IEXSharp/Service/Legacy/Market/IMarketService.cs
@@ -106,7 +106,7 @@ namespace VSLee.IEXSharp.Service.Legacy.Market
 		/// </summary>
 		/// <param name="symbols"></param>
 		/// <returns></returns>
-		Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepActionAsync(IEnumerable<string> symbols);
+		Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepAuctionAsync(IEnumerable<string> symbols);
 
 		/// <summary>
 		/// <see cref="https://iextrading.com/developer/docs/#official-price"/>

--- a/IEXSharp/Service/Legacy/Market/MarketService.cs
+++ b/IEXSharp/Service/Legacy/Market/MarketService.cs
@@ -84,7 +84,7 @@ namespace VSLee.IEXSharp.Service.Legacy.Market
 		public async Task<IEXResponse<Dictionary<string, IEnumerable<DeepTradeResponse>>>> DeepTradeBreaksAsync(IEnumerable<string> symbols)
 			=> await _executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades-breaks", symbols);
 
-		public async Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepActionAsync(IEnumerable<string> symbols)
+		public async Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepAuctionAsync(IEnumerable<string> symbols)
 		  => await _executor.SymbolsExecuteAsync<Dictionary<string, DeepAuctionResponse>>("deep/auction", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepOfficialPriceResponse>>> DeepOfficialPriceAsync(IEnumerable<string> symbols)

--- a/IEXSharpTest/Cloud/APISystemMetadataTest.cs
+++ b/IEXSharpTest/Cloud/APISystemMetadataTest.cs
@@ -1,11 +1,8 @@
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class APISystemMetadataTest
 	{

--- a/IEXSharpTest/Cloud/AccountTest.cs
+++ b/IEXSharpTest/Cloud/AccountTest.cs
@@ -1,10 +1,9 @@
-using NUnit.Framework;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 using VSLee.IEXSharp.Model.Account.Request;
-using VSLee.IEXSharp.Model.Account.Response;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class AccountTest
 	{

--- a/IEXSharpTest/Cloud/AlternativeDataTest.cs
+++ b/IEXSharpTest/Cloud/AlternativeDataTest.cs
@@ -1,9 +1,9 @@
-using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class AlternativeDataTest
 	{

--- a/IEXSharpTest/Cloud/CorporateActionsTest.cs
+++ b/IEXSharpTest/Cloud/CorporateActionsTest.cs
@@ -1,12 +1,12 @@
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using IEXSharp.Model.CorporateActions.Request;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class CorporateActionsTest
 	{

--- a/IEXSharpTest/Cloud/CryptoTest.cs
+++ b/IEXSharpTest/Cloud/CryptoTest.cs
@@ -1,9 +1,9 @@
 using System.Linq;
-using NUnit.Framework;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class CryptoTest
 	{

--- a/IEXSharpTest/Cloud/ForexCurrenciesTest.cs
+++ b/IEXSharpTest/Cloud/ForexCurrenciesTest.cs
@@ -1,9 +1,9 @@
 using System.Linq;
-using NUnit.Framework;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class ForexCurrenciesTest
 	{

--- a/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
+++ b/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
@@ -29,7 +29,7 @@ namespace IEXSharpTest.Cloud
 
 		[Test]
 		[TestCase("ziext")]
-		public async Task DeepActionAsyncTest(params string[] symbols)
+		public async Task DeepAuctionAsyncTest(params string[] symbols)
 		{
 			var response = await sandBoxClient.InvestorsExchangeData.DeepAuctionAsync(symbols);
 

--- a/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
+++ b/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
@@ -28,8 +28,7 @@ namespace VSLee.IEXSharpTest.Cloud
 		}
 
 		[Test]
-		[TestCase("AAPL")]
-		[TestCase("FB")]
+		[TestCase("ziext")]
 		public async Task DeepActionAsyncTest(params string[] symbols)
 		{
 			var response = await sandBoxClient.InvestorsExchangeData.DeepActionAsync(symbols);

--- a/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
+++ b/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
@@ -31,7 +31,7 @@ namespace VSLee.IEXSharpTest.Cloud
 		[TestCase("ziext")]
 		public async Task DeepActionAsyncTest(params string[] symbols)
 		{
-			var response = await sandBoxClient.InvestorsExchangeData.DeepActionAsync(symbols);
+			var response = await sandBoxClient.InvestorsExchangeData.DeepAuctionAsync(symbols);
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);

--- a/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
+++ b/IEXSharpTest/Cloud/InvestorsExchangeDataTest.cs
@@ -1,10 +1,10 @@
-using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class InvestorsExchangeDataTest
 	{

--- a/IEXSharpTest/Cloud/MarketInfoTest.cs
+++ b/IEXSharpTest/Cloud/MarketInfoTest.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using IEXSharp.Model.MarketInfo.Request;
 using VSLee.IEXSharp;
 using VSLee.IEXSharp.Model.MarketInfo.Request;
-using VSLee.IEXSharpTest.Cloud;
 
 namespace IEXSharpTest.Cloud
 {

--- a/IEXSharpTest/Cloud/OptionsTest.cs
+++ b/IEXSharpTest/Cloud/OptionsTest.cs
@@ -1,9 +1,9 @@
-using VSLee.IEXSharp;
-using NUnit.Framework;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using VSLee.IEXSharp;
 using VSLee.IEXSharp.Model.Options.Request;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class OptionsTest
 	{

--- a/IEXSharpTest/Cloud/ReferenceDataTest.cs
+++ b/IEXSharpTest/Cloud/ReferenceDataTest.cs
@@ -1,11 +1,11 @@
-using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 using VSLee.IEXSharp.Model.ReferenceData.Request;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class ReferenceDataTest
 	{

--- a/IEXSharpTest/Cloud/SSETest.cs
+++ b/IEXSharpTest/Cloud/SSETest.cs
@@ -1,10 +1,10 @@
-using VSLee.IEXSharp;
-using VSLee.IEXSharp.Model.Stock.Request;
-using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using VSLee.IEXSharp;
+using VSLee.IEXSharp.Model.Stock.Request;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class SSETest
 	{

--- a/IEXSharpTest/Cloud/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/StockFundamentalsTest.cs
@@ -1,10 +1,10 @@
-using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 using VSLee.IEXSharp.Model.StockFundamentals.Request;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class StockFundamentalsTest
 	{

--- a/IEXSharpTest/Cloud/StockPricesTest.cs
+++ b/IEXSharpTest/Cloud/StockPricesTest.cs
@@ -1,13 +1,13 @@
-using IEXSharp.Helper;
-using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using IEXSharp.Helper;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 using VSLee.IEXSharp.Helper;
 using VSLee.IEXSharp.Model.StockPrices.Request;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class StockPricesTest
 	{

--- a/IEXSharpTest/Cloud/StockProfilesTest.cs
+++ b/IEXSharpTest/Cloud/StockProfilesTest.cs
@@ -1,12 +1,9 @@
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class StockProfilesTest
 	{

--- a/IEXSharpTest/Cloud/StockResearchTest.cs
+++ b/IEXSharpTest/Cloud/StockResearchTest.cs
@@ -1,12 +1,9 @@
-using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class StockResearchResearchTest
 	{

--- a/IEXSharpTest/Cloud/StockTest.cs
+++ b/IEXSharpTest/Cloud/StockTest.cs
@@ -1,14 +1,11 @@
-using VSLee.IEXSharp;
-using VSLee.IEXSharp.Model.Stock.Request;
-using NUnit.Framework;
-using VSLee.IEXSharp.Helper;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using IEXSharp.Helper;
+using NUnit.Framework;
+using VSLee.IEXSharp;
+using VSLee.IEXSharp.Model.Stock.Request;
 
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public class StockTest
 	{

--- a/IEXSharpTest/Cloud/TestGlobal.cs
+++ b/IEXSharpTest/Cloud/TestGlobal.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace VSLee.IEXSharpTest.Cloud
+namespace IEXSharpTest.Cloud
 {
 	public static class TestGlobal
 	{

--- a/IEXSharpTest/Legacy/MarketTest.cs
+++ b/IEXSharpTest/Legacy/MarketTest.cs
@@ -1,10 +1,10 @@
-using VSLee.IEXSharp;
-using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Legacy
+namespace IEXSharpTest.Legacy
 {
 	public class MarketTest
 	{

--- a/IEXSharpTest/Legacy/MarketTest.cs
+++ b/IEXSharpTest/Legacy/MarketTest.cs
@@ -163,7 +163,7 @@ namespace IEXSharpTest.Legacy
 		[Test]
 		[TestCase("AAPL")]
 		[TestCase("FB")]
-		public async Task DeepActionAsyncTest(params string[] symbols)
+		public async Task DeepAuctionAsyncTest(params string[] symbols)
 		{
 			var response = await prodClient.Market.DeepAuctionAsync(symbols);
 

--- a/IEXSharpTest/Legacy/MarketTest.cs
+++ b/IEXSharpTest/Legacy/MarketTest.cs
@@ -165,7 +165,7 @@ namespace VSLee.IEXSharpTest.Legacy
 		[TestCase("FB")]
 		public async Task DeepActionAsyncTest(params string[] symbols)
 		{
-			var response = await prodClient.Market.DeepActionAsync(symbols);
+			var response = await prodClient.Market.DeepAuctionAsync(symbols);
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);

--- a/IEXSharpTest/Legacy/ReferenceDataTest.cs
+++ b/IEXSharpTest/Legacy/ReferenceDataTest.cs
@@ -1,9 +1,9 @@
-using VSLee.IEXSharp;
-using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Legacy
+namespace IEXSharpTest.Legacy
 {
 	public class ReferenceDataTest
 	{

--- a/IEXSharpTest/Legacy/StatsTest.cs
+++ b/IEXSharpTest/Legacy/StatsTest.cs
@@ -1,12 +1,10 @@
-using VSLee.IEXSharp;
-using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using VSLee.IEXSharp;
 
-namespace VSLee.IEXSharpTest.Legacy
+namespace IEXSharpTest.Legacy
 {
 	public class StatsTest
 	{

--- a/IEXSharpTest/Legacy/StockTest.cs
+++ b/IEXSharpTest/Legacy/StockTest.cs
@@ -1,16 +1,16 @@
-using VSLee.IEXSharp;
-using VSLee.IEXSharp.Model.Stock.Request;
-using NUnit.Framework;
-using VSLee.IEXSharp.Helper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using VSLee.IEXSharp.Model.StockPrices.Request;
-using VSLee.IEXSharp.Model.StockFundamentals.Request;
+using NUnit.Framework;
+using VSLee.IEXSharp;
+using VSLee.IEXSharp.Helper;
 using VSLee.IEXSharp.Model.MarketInfo.Request;
+using VSLee.IEXSharp.Model.Stock.Request;
+using VSLee.IEXSharp.Model.StockFundamentals.Request;
+using VSLee.IEXSharp.Model.StockPrices.Request;
 
-namespace VSLee.IEXSharpTest.Legacy
+namespace IEXSharpTest.Legacy
 {
 	public class StockTest
 	{


### PR DESCRIPTION
- Switching test companies for DEEP. (Only IEX listed securities are eligible for IEX Auctions.)
- Fixing typo of DEEP Actions to Auctions.
- Uniform namespaces across all tests for clearer grouping in test explorer.