### PR TITLE
handle empty Split/Dividend result w/ Next param

### DIFF
--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -2,6 +2,7 @@ using IEXSharp.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net.Http;
@@ -76,9 +77,18 @@ namespace IEXSharp.Helper
 					}
 					else
 					{
-						return new IEXResponse<ReturnType>() {
-							Data = JsonConvert.DeserializeObject<ReturnType>(content, jsonSerializerSettings)
-						};
+						if (!typeof(IEnumerable).IsAssignableFrom(typeof(ReturnType))
+							&& content == "[]")
+						{ // if not expecting an array but receive an empty array, return null
+							return null;
+						}
+						else
+						{
+							return new IEXResponse<ReturnType>()
+							{
+								Data = JsonConvert.DeserializeObject<ReturnType>(content, jsonSerializerSettings)
+							};
+						}
 					}
 				}
 				catch (JsonException ex)

--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -71,8 +71,9 @@ namespace IEXSharp.Helper
 						return new IEXResponse<ReturnType>() { ErrorMessage = token["error"].ToString() };
 					}
 					else if (content.Equals("forbidden", StringComparison.InvariantCultureIgnoreCase)
-						|| content.Equals("not found", StringComparison.InvariantCultureIgnoreCase))
-					{ // "Forbidden" or "Not found"
+						|| content.Equals("not found", StringComparison.InvariantCultureIgnoreCase)
+						|| content.Equals("unknown symbol", StringComparison.InvariantCultureIgnoreCase))
+					{ // "Forbidden" or "Not found" or "Unknown symbol"
 						return new IEXResponse<ReturnType>() { ErrorMessage = content };
 					}
 					else

--- a/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
+++ b/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
@@ -89,10 +89,15 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 			{
 				var dividendResponse = await executor.ExecuteAsync<DividendBasicResponse>(urlPattern, pathNvc, qsb);
 
-				return new IEXResponse<IEnumerable<DividendBasicResponse>>()
-				{
-					Data = new List<DividendBasicResponse> { dividendResponse.Data }
-				};
+				return dividendResponse != null
+					? new IEXResponse<IEnumerable<DividendBasicResponse>>()
+					{
+						Data = new List<DividendBasicResponse> { dividendResponse.Data }
+					}
+					: new IEXResponse<IEnumerable<DividendBasicResponse>>()
+					{
+						Data = new List<DividendBasicResponse>()
+					};
 			}
 
 			return await executor.ExecuteAsync<IEnumerable<DividendBasicResponse>>(urlPattern, pathNvc, qsb);
@@ -148,10 +153,15 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 			{
 				var splitResponse = await executor.ExecuteAsync<SplitBasicResponse>(urlPattern, pathNvc, qsb);
 
-				return new IEXResponse<IEnumerable<SplitBasicResponse>>()
-				{
-					Data = new List<SplitBasicResponse> { splitResponse.Data }
-				};
+				return splitResponse != null
+					? new IEXResponse<IEnumerable<SplitBasicResponse>>()
+					{
+						Data = new List<SplitBasicResponse> { splitResponse.Data }
+					}
+					: new IEXResponse<IEnumerable<SplitBasicResponse>>()
+					{
+						Data = new List<SplitBasicResponse>()
+					};
 			}
 
 			return await executor.ExecuteAsync<IEnumerable<SplitBasicResponse>>(urlPattern, pathNvc, qsb);

--- a/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
+++ b/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
@@ -92,6 +92,7 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 				return dividendResponse != null
 					? new IEXResponse<IEnumerable<DividendBasicResponse>>()
 					{
+						ErrorMessage = dividendResponse.ErrorMessage,
 						Data = new List<DividendBasicResponse> { dividendResponse.Data }
 					}
 					: new IEXResponse<IEnumerable<DividendBasicResponse>>()
@@ -156,6 +157,7 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 				return splitResponse != null
 					? new IEXResponse<IEnumerable<SplitBasicResponse>>()
 					{
+						ErrorMessage = splitResponse.ErrorMessage,
 						Data = new List<SplitBasicResponse> { splitResponse.Data }
 					}
 					: new IEXResponse<IEnumerable<SplitBasicResponse>>()

--- a/IEXSharpTest/Cloud/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/StockFundamentalsTest.cs
@@ -71,6 +71,8 @@ namespace IEXSharpTest.Cloud
 		[TestCase("AAPL", DividendRange.FiveYears)]
 		[TestCase("AAPL", DividendRange.SixMonths)]
 		[TestCase("AAPL", DividendRange.Next)]
+		[TestCase("AMLP", DividendRange.Next)]
+		[TestCase("ZIEXT", DividendRange.Next)]
 		[TestCase("AAPL", DividendRange.Ytd)]
 		public async Task DividendsBasicAsyncTest(string symbol, DividendRange range)
 		{
@@ -172,7 +174,9 @@ namespace IEXSharpTest.Cloud
 		[TestCase("AAPL", SplitRange.ThreeMonths)]
 		[TestCase("AAPL", SplitRange.FiveYears)]
 		[TestCase("AAPL", SplitRange.SixMonths)]
+		[TestCase("AAPL", SplitRange.Next)]
 		[TestCase("AMLP", SplitRange.Next)]
+		[TestCase("ZIEXT", SplitRange.Next)]
 		[TestCase("AAPL", SplitRange.Ytd)]
 		public async Task SplitsBasicAsyncTest(string symbol, SplitRange range)
 		{

--- a/IEXSharpTest/Cloud/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/StockFundamentalsTest.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using IEXSharp;
 using IEXSharp.Model.Shared.Request;
 using IEXSharp.Model.StockFundamentals.Request;
+using System;
 
 namespace IEXSharpTest.Cloud
 {
@@ -72,7 +73,6 @@ namespace IEXSharpTest.Cloud
 		[TestCase("AAPL", DividendRange.SixMonths)]
 		[TestCase("AAPL", DividendRange.Next)]
 		[TestCase("AMLP", DividendRange.Next)]
-		[TestCase("ZIEXT", DividendRange.Next)]
 		[TestCase("AAPL", DividendRange.Ytd)]
 		public async Task DividendsBasicAsyncTest(string symbol, DividendRange range)
 		{
@@ -81,6 +81,15 @@ namespace IEXSharpTest.Cloud
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
 		}
+
+		[TestCase("ZIEXT", DividendRange.Next)]
+		public async Task DividendsBasicAsyncWithUnknownSymbolTest(string symbol, DividendRange range)
+		{
+			var response = await sandBoxClient.StockFundamentals.DividendsBasicAsync(symbol, range);
+
+			Assert.IsTrue(response.ErrorMessage.Equals("unknown symbol", StringComparison.InvariantCultureIgnoreCase));
+		}
+
 
 		[Test]
 		[TestCase("AAPL", 1)]
@@ -174,9 +183,7 @@ namespace IEXSharpTest.Cloud
 		[TestCase("AAPL", SplitRange.ThreeMonths)]
 		[TestCase("AAPL", SplitRange.FiveYears)]
 		[TestCase("AAPL", SplitRange.SixMonths)]
-		[TestCase("AAPL", SplitRange.Next)]
 		[TestCase("AMLP", SplitRange.Next)]
-		[TestCase("ZIEXT", SplitRange.Next)]
 		[TestCase("AAPL", SplitRange.Ytd)]
 		public async Task SplitsBasicAsyncTest(string symbol, SplitRange range)
 		{
@@ -184,6 +191,14 @@ namespace IEXSharpTest.Cloud
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
+		}
+
+		[TestCase("ZIEXT", SplitRange.Next)]
+		public async Task SplitsBasicAsyncUnkownSymbolTest(string symbol, SplitRange range)
+		{
+			var response = await sandBoxClient.StockFundamentals.SplitsBasicAsync(symbol, range);
+
+			Assert.IsTrue(response.ErrorMessage.Equals("unknown symbol", StringComparison.InvariantCultureIgnoreCase));
 		}
 	}
 }

--- a/IEXSharpTest/Cloud/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/StockFundamentalsTest.cs
@@ -87,7 +87,7 @@ namespace IEXSharpTest.Cloud
 		{
 			var response = await sandBoxClient.StockFundamentals.DividendsBasicAsync(symbol, range);
 
-			Assert.IsTrue(response.ErrorMessage.Equals("unknown symbol", StringComparison.InvariantCultureIgnoreCase));
+			Assert.IsTrue(response.ErrorMessage.Equals("NotFound - Unknown symbol", StringComparison.InvariantCultureIgnoreCase));
 		}
 
 
@@ -198,7 +198,7 @@ namespace IEXSharpTest.Cloud
 		{
 			var response = await sandBoxClient.StockFundamentals.SplitsBasicAsync(symbol, range);
 
-			Assert.IsTrue(response.ErrorMessage.Equals("unknown symbol", StringComparison.InvariantCultureIgnoreCase));
+			Assert.IsTrue(response.ErrorMessage.Equals("NotFound - Unknown symbol", StringComparison.InvariantCultureIgnoreCase));
 		}
 	}
 }


### PR DESCRIPTION
- for Split/Dividend, IEX normally returns a JSON array of results
- however, when using Range set to Next, IEX returns a single result that is not enclosed in a JSON array
- we had previously added code to handle this single result
- however, if the Next result is actually nothing, then IEX returns an empty array
- this adds handling of this corner case in ExecuteAsync()
- the user likely expects an IEXResponse with the Data being an empty List, rather than Data being null
(if the Data were null, it could screw up LINQ or other manipulation that the user performs on the Data IEnumerable)
- thus, the Split/Dividend methods have been modified to return this empty List if needed
- the Split/Dividend code has also been updated to pass through the ErrorMessage (if any)
- ExecuteAsync() can now handle an additional error message: "Unknown Symbol"