### PR TITLE
simplify Split/Dividend special case fix

### DIFF
--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -68,18 +68,15 @@ namespace IEXSharp.Helper
 					content = await responseContent.Content.ReadAsStringAsync();
 					if (responseContent.StatusCode == HttpStatusCode.OK)
 					{ // Successful Request
-						if (!typeof(IEnumerable).IsAssignableFrom(typeof(ReturnType))
-							&& content == "[]")
-						{ // if not expecting an array but receive an empty array, return null
-							return null;
+						if (typeof(IEnumerable).IsAssignableFrom(typeof(ReturnType))
+							&& content[0] != '[')
+						{ // if expecting an array but receive a single item instead, create a new List with that single item
+							content = '[' + content + ']';
 						}
-						else
+						return new IEXResponse<ReturnType>()
 						{
-							return new IEXResponse<ReturnType>()
-							{
-								Data = JsonConvert.DeserializeObject<ReturnType>(content, jsonSerializerSettings)
-							};
-						}
+							Data = JsonConvert.DeserializeObject<ReturnType>(content, jsonSerializerSettings)
+						};
 					}
 					else
 					{ // Failed Request

--- a/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
+++ b/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
@@ -85,22 +85,6 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 				{"symbol", symbol}, {"range", range.GetDescriptionFromEnum()}
 			};
 
-			if (range == DividendRange.Next)
-			{
-				var dividendResponse = await executor.ExecuteAsync<DividendBasicResponse>(urlPattern, pathNvc, qsb);
-
-				return dividendResponse != null
-					? new IEXResponse<IEnumerable<DividendBasicResponse>>()
-					{
-						ErrorMessage = dividendResponse.ErrorMessage,
-						Data = new List<DividendBasicResponse> { dividendResponse.Data }
-					}
-					: new IEXResponse<IEnumerable<DividendBasicResponse>>()
-					{
-						Data = new List<DividendBasicResponse>()
-					};
-			}
-
 			return await executor.ExecuteAsync<IEnumerable<DividendBasicResponse>>(urlPattern, pathNvc, qsb);
 		}
 
@@ -148,23 +132,6 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 			var qsb = new QueryStringBuilder();
 
 			var pathNvc = new NameValueCollection { { "symbol", symbol }, { "range", range.GetDescriptionFromEnum() } };
-
-
-			if (range == SplitRange.Next)
-			{
-				var splitResponse = await executor.ExecuteAsync<SplitBasicResponse>(urlPattern, pathNvc, qsb);
-
-				return splitResponse != null
-					? new IEXResponse<IEnumerable<SplitBasicResponse>>()
-					{
-						ErrorMessage = splitResponse.ErrorMessage,
-						Data = new List<SplitBasicResponse> { splitResponse.Data }
-					}
-					: new IEXResponse<IEnumerable<SplitBasicResponse>>()
-					{
-						Data = new List<SplitBasicResponse>()
-					};
-			}
 
 			return await executor.ExecuteAsync<IEnumerable<SplitBasicResponse>>(urlPattern, pathNvc, qsb);
 		}


### PR DESCRIPTION
- now generalized to anytime a single item is received when expecting an array
- thus, able to place in ExecuteAsync() directly
- fix turned out to be simpler than I thought. Initially, I thought I was going to have to use reflection to get the type argument from `<ReturnType>` and then instantiate a new list and then Deserialize from that.