### PR TITLE
Make UnitTests fail when there is a new Json value in the REST reponse not being parsed

### DIFF
--- a/IEXSharp/Assembly.cs
+++ b/IEXSharp/Assembly.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("IEXSharpTest")]

--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -16,7 +16,8 @@ namespace IEXSharp.Helper
 		private readonly HttpClient client;
 		private readonly Signer signer;
 		private readonly bool sign;
-		private readonly JsonSerializerSettings jsonSerializerSettings;
+
+		internal readonly JsonSerializerSettings JsonSerializerSettings;
 
 		public ExecutorREST(HttpClient client, string publishableToken, string secretToken, bool sign)
 			: base(publishableToken: publishableToken, secretToken: secretToken)
@@ -27,7 +28,7 @@ namespace IEXSharp.Helper
 				signer = new Signer(client.BaseAddress.Host, secretToken);
 			}
 			this.sign = sign;
-			jsonSerializerSettings = new JsonSerializerSettings
+			JsonSerializerSettings = new JsonSerializerSettings
 			{
 				NullValueHandling = NullValueHandling.Ignore
 			};
@@ -81,14 +82,14 @@ namespace IEXSharp.Helper
 							&& typeof(ReturnType) != typeof(string)
 							// Dictionaries will also be assignable from IEnumerable but it is expected
 							// that their JSON representation would begin with "{" instead of "["
-							&& !typeof(IDictionary).IsAssignableFrom(typeof(ReturnType)) 
+							&& !typeof(IDictionary).IsAssignableFrom(typeof(ReturnType))
 							&& content[0] != '[')
 						{ // if expecting an array but receive a single item instead, create a new List with that single item
 							content = '[' + content + ']';
 						}
 						return new IEXResponse<ReturnType>()
 						{
-							Data = JsonConvert.DeserializeObject<ReturnType>(content, jsonSerializerSettings)
+							Data = JsonConvert.DeserializeObject<ReturnType>(content, JsonSerializerSettings)
 						};
 					}
 					else

--- a/IEXSharp/IEXCloudClient.cs
+++ b/IEXSharp/IEXCloudClient.cs
@@ -47,8 +47,8 @@ namespace IEXSharp
 		private readonly string secretToken;
 		private readonly bool signRequest;
 
-		private readonly ExecutorREST executor;
-		private readonly ExecutorSSE executorSSE;
+		internal readonly ExecutorREST executor;
+		internal readonly ExecutorSSE executorSSE;
 
 		private IBatchService batchService;
 		private IAccountService accountService;

--- a/IEXSharp/IEXCloudClient.cs
+++ b/IEXSharp/IEXCloudClient.cs
@@ -20,6 +20,7 @@ using IEXSharp.Service.Cloud.StockResearch;
 using IEXSharp.Service.Cloud.Treasuries;
 using System;
 using System.Net.Http;
+using IEXSharp.Helper;
 
 namespace IEXSharp
 {
@@ -45,6 +46,9 @@ namespace IEXSharp
 		private readonly string publishableToken;
 		private readonly string secretToken;
 		private readonly bool signRequest;
+
+		private readonly ExecutorREST executor;
+		private readonly ExecutorSSE executorSSE;
 
 		private IBatchService batchService;
 		private IAccountService accountService;
@@ -74,121 +78,121 @@ namespace IEXSharp
 		/// Currently only available for /stock endpoints
 		/// </summary>
 		public IBatchService Batch => batchService ?? (batchService =
-			new BatchService(client, publishableToken, secretToken, signRequest));
+			new BatchService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#accounts"/>
 		/// </summary>
 		public IAccountService Account => accountService ??	(accountService =
-			new AccountService(client, publishableToken, secretToken, signRequest));
+			new AccountService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#api-system-metadata"/>
 		/// </summary>
 		public IAPISystemMetadataService ApiSystemMetadata => apiSystemMetadataService
-			?? (apiSystemMetadataService = new APISystemMetadata(client, publishableToken, secretToken, signRequest));
+			?? (apiSystemMetadataService = new APISystemMetadata(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#stock-prices"/>
 		/// </summary>
 		public IStockPricesService StockPrices => stockPricesService ?? (stockPricesService =
-			new StockPricesService(client, baseSSEURL, publishableToken, secretToken, signRequest));
+			new StockPricesService(executor, executorSSE));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#stock-profiles"/>
 		/// </summary>
 		public IStockProfilesService StockProfiles => stockProfilesService ?? (stockProfilesService =
-			new StockProfilesService(client, publishableToken, secretToken, signRequest));
+			new StockProfilesService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#stock-fundamentals"/>
 		/// </summary>
 		public IStockFundamentalsService StockFundamentals => stockFundamentalsService ?? (stockFundamentalsService =
-			new StockFundamentalsService(client, publishableToken, secretToken, signRequest));
+			new StockFundamentalsService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#stock-research"/>
 		/// </summary>
 		public IStockResearchService StockResearch => stockResearchService ?? (stockResearchService =
-			new StockResearchService(client, publishableToken, secretToken, signRequest));
+			new StockResearchService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#corporate-actions"/>
 		/// </summary>
 		public ICorporateActionsService CorporateActions => corporateActionsService
-			?? (corporateActionsService = new CorporateActionsService(client, publishableToken, secretToken, signRequest));
+			?? (corporateActionsService = new CorporateActionsService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#market-info"/>
 		/// </summary>
 		public IMarketInfoService MarketInfoService => marketInfoService
-			?? (marketInfoService = new MarketInfoService(client, publishableToken, secretToken, signRequest));
+			?? (marketInfoService = new MarketInfoService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#news"/>
 		/// </summary>
 		public INewsService News => newsService
-			?? (newsService = new NewsService(client, baseSSEURL, publishableToken, secretToken, signRequest));
+			?? (newsService = new NewsService(executor, executorSSE));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#cryptocurrency"/>
 		/// </summary>
 		public ICryptoService Crypto => cryptoService ??
-		    (cryptoService = new CryptoService(client, baseSSEURL, publishableToken, secretToken, signRequest));
+		    (cryptoService = new CryptoService(executor, executorSSE));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#forex-currencies"/>
 		/// </summary>
 		public IForexCurrenciesService ForexCurrencies => forexCurrenciesService ??
-			(forexCurrenciesService = new ForexCurrenciesService(client, publishableToken, secretToken, signRequest));
+			(forexCurrenciesService = new ForexCurrenciesService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#options"/>
 		/// </summary>
 		public IOptionsService Options => optionsService
-			?? (optionsService = new OptionsService(client, secretToken, publishableToken, signRequest));
+			?? (optionsService = new OptionsService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#social-sentiment"/>
 		/// </summary>
 		public ISocialSentimentService SocialSentiment => socialSentimentService
-			?? (socialSentimentService = new SocialSentimentService(client, baseSSEURL, publishableToken, secretToken, signRequest));
+			?? (socialSentimentService = new SocialSentimentService(executor, executorSSE));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#ceo-compensation"/>
 		/// </summary>
 		public ICeoCompensationService CeoCompensation => ceoCompensationService
-			?? (ceoCompensationService = new CeoCompensationService(client, publishableToken, secretToken, signRequest));
+			?? (ceoCompensationService = new CeoCompensationService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#treasuries"/>
 		/// </summary>
 		public ITreasuriesService Treasuries => treasuriesService
-			?? (treasuriesService = new TreasuriesService(client, publishableToken, secretToken, signRequest));
+			?? (treasuriesService = new TreasuriesService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#commodities"/>
 		/// </summary>
 		public ICommoditiesService Commodities => commoditiesService
-			?? (commoditiesService = new CommoditiesService(client, publishableToken, secretToken, signRequest));
+			?? (commoditiesService = new CommoditiesService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#economic-data"/>
 		/// </summary>
 		public IEconomicDataService EconomicData => economicDataService
-			?? (economicDataService = new EconomicDataService(client, publishableToken, secretToken, signRequest));
+			?? (economicDataService = new EconomicDataService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#reference-data"/>
 		/// </summary>
 		public IReferenceDataService ReferenceData => referenceDataService ??
-			(referenceDataService = new ReferenceDataService(client, publishableToken, secretToken, signRequest));
+			(referenceDataService = new ReferenceDataService(executor));
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#investors-exchange-data"/>
 		/// </summary>
 		public IInvestorsExchangeDataService InvestorsExchangeData =>
-			investorsExchangeDataService ?? (investorsExchangeDataService = new InvestorsExchangeDataService(client, publishableToken, secretToken, signRequest));
+			investorsExchangeDataService ?? (investorsExchangeDataService = new InvestorsExchangeDataService(executor));
 
 		/// <summary>
 		/// create a new IEXCloudClient
@@ -220,6 +224,9 @@ namespace IEXSharp
 				BaseAddress = new Uri(baseAddress)
 			};
 			client.DefaultRequestHeaders.Add("User-Agent", "VSLee.IEXSharp IEX Cloud .Net");
+
+			executor = new ExecutorREST(client, publishableToken, secretToken, signRequest);
+			executorSSE = new ExecutorSSE(baseSSEURL, publishableToken, secretToken);
 		}
 
 		private bool disposed;

--- a/IEXSharp/IEXCloudClient.cs
+++ b/IEXSharp/IEXCloudClient.cs
@@ -47,8 +47,8 @@ namespace IEXSharp
 		private readonly string secretToken;
 		private readonly bool signRequest;
 
-		internal readonly ExecutorREST executor;
-		internal readonly ExecutorSSE executorSSE;
+		private protected readonly ExecutorREST executor;
+		private protected ExecutorSSE executorSSE;
 
 		private IBatchService batchService;
 		private IAccountService accountService;

--- a/IEXSharp/IEXLegacyClient.cs
+++ b/IEXSharp/IEXLegacyClient.cs
@@ -4,6 +4,7 @@ using IEXSharp.Service.Legacy.Stats;
 using IEXSharp.Service.Legacy.Stock;
 using System;
 using System.Net.Http;
+using IEXSharp.Helper;
 
 namespace IEXSharp
 {
@@ -12,22 +13,24 @@ namespace IEXSharp
 	{
 		private readonly HttpClient _client;
 
+		private readonly ExecutorREST executor;
+
 		private IStockService stockService;
 		private IReferenceDataService referenceDataService;
 		private IMarketService marketService;
 		private IStatsService statsService;
 
 		public IStockService Stock =>
-			stockService ?? (stockService = new StockService(_client));
+			stockService ?? (stockService = new StockService(executor));
 
 		public IReferenceDataService ReferenceData => referenceDataService ??
-			(referenceDataService = new ReferenceDataService(_client));
+			(referenceDataService = new ReferenceDataService(executor));
 
 		public IMarketService Market =>
-			marketService ?? (marketService = new MarketService(_client));
+			marketService ?? (marketService = new MarketService(executor));
 
 		public IStatsService Stats =>
-			statsService ?? (statsService = new StatsService(_client));
+			statsService ?? (statsService = new StatsService(executor));
 
 		/// <summary> create a new IEXLegacyClient. No API keys are needed. </summary>
 		public IEXLegacyClient()
@@ -37,6 +40,8 @@ namespace IEXSharp
 				BaseAddress = new Uri("https://api.iextrading.com/1.0/")
 			};
 			_client.DefaultRequestHeaders.Add("User-Agent", "IEXSharp IEX Legacy .Net");
+
+			executor = new ExecutorREST(_client, string.Empty, string.Empty, false);
 		}
 
 		private bool disposed;

--- a/IEXSharp/Model/MarketInfo/Response/IPOCalendarResponse.cs
+++ b/IEXSharp/Model/MarketInfo/Response/IPOCalendarResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace IEXSharp.Model.MarketInfo.Response
@@ -6,6 +7,7 @@ namespace IEXSharp.Model.MarketInfo.Response
 	{
 		public List<RawData> rawData { get; set; }
 		public List<ViewData> viewData { get; set; }
+		public DateTime lastUpdate { get; set; }
 	}
 
 	public class RawData
@@ -54,6 +56,12 @@ namespace IEXSharp.Model.MarketInfo.Response
 
 	public class ViewData
 	{
+		public class Quote
+		{
+			public float latestPrice { get; set; }
+			public float changePercent { get; set; }
+		}
+
 		public string Company { get; set; }
 		public string Symbol { get; set; }
 		public string Price { get; set; }
@@ -63,5 +71,6 @@ namespace IEXSharp.Model.MarketInfo.Response
 		public string Percent { get; set; }
 		public string Market { get; set; }
 		public string Expected { get; set; }
+		public ViewData.Quote quote { get; set; }
 	}
 }

--- a/IEXSharp/Model/MarketInfo/Response/UpcomingEarningEvent.cs
+++ b/IEXSharp/Model/MarketInfo/Response/UpcomingEarningEvent.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace IEXSharp.Model.MarketInfo.Response
+{
+	public class UpcomingEarningEvent
+	{
+		public string symbol { get; set; }
+		public DateTime reportDate { get; set; }
+	}
+}

--- a/IEXSharp/Model/MarketInfo/Response/UpcomingEventResponse.cs
+++ b/IEXSharp/Model/MarketInfo/Response/UpcomingEventResponse.cs
@@ -15,7 +15,7 @@ namespace IEXSharp.Model.MarketInfo.Response
 	public class UpcomingEventMarketResponse
 	{
 		public IPOCalendarResponse ipos { get; set; }
-		public List<Estimate> earnings { get; set; }
+		public List<UpcomingEarningEvent> earnings { get; set; }
 		public List<Dividend> dividends { get; set; }
 		public List<Split> splits { get; set; }
 	}

--- a/IEXSharp/Model/ReferenceData/Response/ExchangeInternationalResponse.cs
+++ b/IEXSharp/Model/ReferenceData/Response/ExchangeInternationalResponse.cs
@@ -5,5 +5,7 @@ namespace IEXSharp.Model.ReferenceData.Response
 		public string exchange { get; set; }
 		public string region { get; set; }
 		public string description { get; set; }
+		public string mic { get; set; }
+		public string exchangeSuffix { get; set; }
 	}
 }

--- a/IEXSharp/Model/ReferenceData/Response/ExchangeUSResponse.cs
+++ b/IEXSharp/Model/ReferenceData/Response/ExchangeUSResponse.cs
@@ -2,10 +2,12 @@ namespace IEXSharp.Model.ReferenceData.Response
 {
 	public class ExchangeUSResponse
 	{
-		public string name { get; set; }
 		public string mic { get; set; }
+		public string name { get; set; }
+		public string longName { get; set; }
 		public string tapeId { get; set; }
 		public string oatsId { get; set; }
+		public string refId { get; set; }
 		public string type { get; set; }
 	}
 }

--- a/IEXSharp/Model/ReferenceData/Response/SymbolInternationalResponse.cs
+++ b/IEXSharp/Model/ReferenceData/Response/SymbolInternationalResponse.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace IEXSharp.Model.ReferenceData.Response
 {
 	public class SymbolInternationalResponse
@@ -5,11 +7,13 @@ namespace IEXSharp.Model.ReferenceData.Response
 		public string symbol { get; set; }
 		public string exchange { get; set; }
 		public string name { get; set; }
-		public string date { get; set; }
+		public DateTime date { get; set; }
 		public string type { get; set; }
 		public string iexId { get; set; }
 		public string region { get; set; }
 		public string currency { get; set; }
 		public bool isEnabled { get; set; }
+		public string figi { get; set; }
+		public string cik { get; set; }
 	}
 }

--- a/IEXSharp/Model/ReferenceData/Response/SymbolMutualFundResponse.cs
+++ b/IEXSharp/Model/ReferenceData/Response/SymbolMutualFundResponse.cs
@@ -1,14 +1,19 @@
+using System;
+
 namespace IEXSharp.Model.ReferenceData.Response
 {
 	public class SymbolMutualFundResponse
 	{
 		public string symbol { get; set; }
+		public string exchange { get; set; }
 		public string name { get; set; }
-		public string date { get; set; }
+		public DateTime date { get; set; }
 		public string type { get; set; }
 		public string iexId { get; set; }
 		public string region { get; set; }
 		public string currency { get; set; }
 		public bool isEnabled { get; set; }
+		public string figi { get; set; }
+		public string cik { get; set; }
 	}
 }

--- a/IEXSharp/Model/ReferenceData/Response/SymbolResponse.cs
+++ b/IEXSharp/Model/ReferenceData/Response/SymbolResponse.cs
@@ -5,6 +5,7 @@ namespace IEXSharp.Model.ReferenceData.Response
 	public class SymbolResponse
 	{
 		public string symbol { get; set; }
+		public string exchange { get; set; }
 		public string name { get; set; }
 		public DateTime date { get; set; }
 		public string type { get; set; }
@@ -12,5 +13,7 @@ namespace IEXSharp.Model.ReferenceData.Response
 		public string region { get; set; }
 		public string currency { get; set; }
 		public bool isEnabled { get; set; }
+		public string figi { get; set; }
+		public string cik { get; set; }
 	}
 }

--- a/IEXSharp/Model/Shared/Response/CashFlow.cs
+++ b/IEXSharp/Model/Shared/Response/CashFlow.cs
@@ -5,6 +5,8 @@ namespace IEXSharp.Model.Shared.Response
 	public class Cashflow
 	{
 		public DateTime reportDate { get; set; }
+		public DateTime fiscalDate { get; set; }
+		public string currency { get; set; }
 		public long netIncome { get; set; }
 		public long depreciation { get; set; }
 		public long changesInReceivables { get; set; }

--- a/IEXSharp/Model/Shared/Response/Dividend.cs
+++ b/IEXSharp/Model/Shared/Response/Dividend.cs
@@ -38,6 +38,7 @@ namespace IEXSharp.Model.Shared.Response
 		public string currency { get; set; }
 		public string description { get; set; }
 		public string frequency { get; set; }
+		public string symbol { get; set; }
 		public DividendFrequency DividendFrequency =>
 			(DividendFrequency)Enum.Parse(typeof(DividendFrequency), frequency);
 	}

--- a/IEXSharp/Model/Shared/Response/Earning.cs
+++ b/IEXSharp/Model/Shared/Response/Earning.cs
@@ -12,5 +12,6 @@
 		public string fiscalEndDate { get; set; }
 		public decimal yearAgo { get; set; }
 		public decimal yearAgoChangePercent { get; set; }
+		public string currency { get; set; }
 	}
 }

--- a/IEXSharp/Model/Shared/Response/Financial.cs
+++ b/IEXSharp/Model/Shared/Response/Financial.cs
@@ -5,6 +5,8 @@ namespace IEXSharp.Model.Shared.Response
 	public class Financial
 	{
 		public DateTime reportDate { get; set; }
+		public DateTime fiscalDate { get; set; }
+		public string currency { get; set; }
 		public long grossProfit { get; set; }
 		public long costOfRevenue { get; set; }
 		public long operatingRevenue { get; set; }
@@ -18,11 +20,12 @@ namespace IEXSharp.Model.Shared.Response
 		public long totalLiabilities { get; set; }
 		public long currentCash { get; set; }
 		public long currentDebt { get; set; }
+		public long shortTermDebt { get; set; }
+		public long longTermDebt { get; set; }
 		public long totalCash { get; set; }
 		public long totalDebt { get; set; }
 		public long shareholderEquity { get; set; }
 		public long cashChange { get; set; }
 		public long cashFlow { get; set; }
-		public string operatingGainsLosses { get; set; }
 	}
 }

--- a/IEXSharp/Model/Shared/Response/Pair.cs
+++ b/IEXSharp/Model/Shared/Response/Pair.cs
@@ -2,7 +2,8 @@
 {
 	public class Pair
 	{
-		public string from { get; set; }
-		public string to { get; set; }
+		public string fromCurrency { get; set; }
+		public string toCurrency { get; set; }
+		public string symbol { get; set; }
 	}
 }

--- a/IEXSharp/Model/Shared/Response/Quote.cs
+++ b/IEXSharp/Model/Shared/Response/Quote.cs
@@ -4,13 +4,20 @@ namespace IEXSharp.Model.Shared.Response
 	{
 		public string symbol { get; set; }
 		public string companyName { get; set; }
+		public string primaryExchange { get; set; }
 		public string calculationPrice { get; set; }
 		public decimal open { get; set; }
 		public long openTime { get; set; }
+		public string openSource { get; set; }
 		public decimal close { get; set; }
 		public long closeTime { get; set; }
+		public string closeSource { get; set; }
 		public decimal high { get; set; }
+		public long highTime { get; set; }
+		public string highSource { get; set; }
 		public decimal low { get; set; }
+		public long lowTime { get; set; }
+		public string lowSource { get; set; }
 		public decimal latestPrice { get; set; }
 		public string latestSource { get; set; }
 		public string latestTime { get; set; }
@@ -21,13 +28,17 @@ namespace IEXSharp.Model.Shared.Response
 		public long iexLastUpdated { get; set; }
 		public decimal delayedPrice { get; set; }
 		public long delayedPriceTime { get; set; }
+		public decimal oddLotDelayedPrice { get; set; }
+		public decimal oddLotDelayedPriceTime { get; set; }
 		public decimal extendedPrice { get; set; }
 		public decimal extendedChange { get; set; }
 		public decimal extendedChangePercent { get; set; }
 		public long extendedPriceTime { get; set; }
 		public decimal previousClose { get; set; }
+		public int previousVolume { get; set; }
 		public decimal change { get; set; }
 		public decimal changePercent { get; set; }
+		public decimal volume { get; set; }
 		public decimal iexMarketPercent { get; set; }
 		public int iexVolume { get; set; }
 		public int avgTotalVolume { get; set; }
@@ -35,14 +46,17 @@ namespace IEXSharp.Model.Shared.Response
 		public int iexBidSize { get; set; }
 		public decimal iexAskPrice { get; set; }
 		public int iexAskSize { get; set; }
+		public decimal iexOpen { get; set; }
+		public decimal iexOpenTime { get; set; }
+		public decimal iexClose { get; set; }
+		public long iexCloseTime { get; set; }
 		public long marketCap { get; set; }
 		public decimal peRatio { get; set; }
 		public decimal week52High { get; set; }
 		public decimal week52Low { get; set; }
 		public decimal ytdChange { get; set; }
-		public decimal? bidPrice { get; set; }
-		public decimal? bidSize { get; set; }
-		public decimal? askPrice { get; set; }
-		public decimal? askSize { get; set; }
+		public long lastTradeTime { get; set; }
+		public bool isUSMarketOpen { get; set; }
+		public string sector { get; set; }
 	}
 }

--- a/IEXSharp/Model/StockFundamentals/Response/BalanceSheetResponse.cs
+++ b/IEXSharp/Model/StockFundamentals/Response/BalanceSheetResponse.cs
@@ -12,6 +12,8 @@ namespace IEXSharp.Model.StockFundamentals.Response
 	public class Balancesheet
 	{
 		public DateTime reportDate { get; set; }
+		public DateTime fiscalDate { get; set; }
+		public string currency { get; set; }
 		public long currentCash { get; set; }
 		public long shortTermInvestments { get; set; }
 		public long receivables { get; set; }

--- a/IEXSharp/Model/StockFundamentals/Response/DividendResponse.cs
+++ b/IEXSharp/Model/StockFundamentals/Response/DividendResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using IEXSharp.Model.Shared.Response;
 
 namespace IEXSharp.Model.StockFundamentals.Response
@@ -6,5 +7,6 @@ namespace IEXSharp.Model.StockFundamentals.Response
 
 	public class DividendBasicResponse : Dividend
 	{
+		public DateTime date { get; set; }
 	}
 }

--- a/IEXSharp/Model/StockFundamentals/Response/EarningTodayResponse.cs
+++ b/IEXSharp/Model/StockFundamentals/Response/EarningTodayResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using IEXSharp.Model.Shared.Response;
 
@@ -17,14 +18,16 @@ namespace IEXSharp.Model.StockFundamentals.Response
 			public string announceTime { get; set; }
 			public long numberOfEstimates { get; set; }
 			public decimal EPSSurpriseDollar { get; set; }
-			public string EPSReportDate { get; set; }
+			public DateTime EPSReportDate { get; set; }
 			public string fiscalPeriod { get; set; }
-			public string fiscalEndDate { get; set; }
+			public DateTime fiscalEndDate { get; set; }
 			public decimal yearAgo { get; set; }
 			public decimal yearAgoChangePercent { get; set; }
 			public decimal estimatedChangePercent { get; set; }
 			public int symbolId { get; set; }
 			public string symbol { get; set; }
+			public DateTime reportDate { get; set; }
+			public string currency { get; set; }
 			public Quote quote { get; set; }
 			public string headline { get; set; }
 		}
@@ -36,6 +39,8 @@ namespace IEXSharp.Model.StockFundamentals.Response
 			public string fiscalPeriod { get; set; }
 			public string fiscalEndDate { get; set; }
 			public string symbol { get; set; }
+			public string reportDate { get; set; }
+			public string currency { get; set; }
 			public Quote quote { get; set; }
 		}
 	}

--- a/IEXSharp/Model/StockFundamentals/Response/IncomeStatementResponse.cs
+++ b/IEXSharp/Model/StockFundamentals/Response/IncomeStatementResponse.cs
@@ -12,6 +12,8 @@ namespace IEXSharp.Model.StockFundamentals.Response
 	public class Income
 	{
 		public DateTime reportDate { get; set; }
+		public DateTime fiscalDate { get; set; }
+		public string currency { get; set; }
 		public long totalRevenue { get; set; }
 		public long costOfRevenue { get; set; }
 		public long grossProfit { get; set; }

--- a/IEXSharp/Model/StockFundamentals/Response/Split.cs
+++ b/IEXSharp/Model/StockFundamentals/Response/Split.cs
@@ -21,5 +21,6 @@ namespace IEXSharp.Model.StockFundamentals.Response
 		public decimal toFactor { get; set; }
 		public decimal fromFactor { get; set; }
 		public string description { get; set; }
+		public string symbol { get; set; }
 	}
 }

--- a/IEXSharp/Service/Cloud/APISystemMetadata/APISystemMetadata.cs
+++ b/IEXSharp/Service/Cloud/APISystemMetadata/APISystemMetadata.cs
@@ -8,14 +8,14 @@ namespace IEXSharp.Service.Cloud.APISystemMetadata
 {
 	internal class APISystemMetadata : IAPISystemMetadataService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
-		public APISystemMetadata(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal APISystemMetadata(ExecutorREST executor)
 		{
-			_executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<StatusResponse>> StatusAsync() =>
-			await _executor.NoParamExecute<StatusResponse>("status");
+			await executor.NoParamExecute<StatusResponse>("status");
 	}
 }

--- a/IEXSharp/Service/Cloud/Account/AccountService.cs
+++ b/IEXSharp/Service/Cloud/Account/AccountService.cs
@@ -11,11 +11,11 @@ namespace IEXSharp.Service.Cloud.Account
 {
 	internal class AccountService : IAccountService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
-		public AccountService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal AccountService(ExecutorREST executor)
 		{
-			_executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<MetadataResponse>> MetadataAsync()
@@ -26,7 +26,7 @@ namespace IEXSharp.Service.Cloud.Account
 
 			var pathNVC = new NameValueCollection();
 
-			return await _executor.ExecuteAsync<MetadataResponse>(urlPattern, pathNVC, qsb, forceUseSecretToken: true);
+			return await executor.ExecuteAsync<MetadataResponse>(urlPattern, pathNVC, qsb, forceUseSecretToken: true);
 		}
 
 		public async Task<IEXResponse<UsageResponse>> UsageAsync(UsageType type)
@@ -42,7 +42,7 @@ namespace IEXSharp.Service.Cloud.Account
 				pathNVC["type"] = type.GetDescriptionFromEnum();
 			}
 
-			return await _executor.ExecuteAsync<UsageResponse>(urlPattern, pathNVC, qsb, forceUseSecretToken: true);
+			return await executor.ExecuteAsync<UsageResponse>(urlPattern, pathNVC, qsb, forceUseSecretToken: true);
 		}
 
 		public Task PayAsYouGoAsync(bool allow)

--- a/IEXSharp/Service/Cloud/Batch/BatchService.cs
+++ b/IEXSharp/Service/Cloud/Batch/BatchService.cs
@@ -15,9 +15,9 @@ namespace IEXSharp.Service.Cloud.Batch
 	{
 		private readonly ExecutorREST executor;
 
-		public BatchService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal BatchService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<BatchResponse>>

--- a/IEXSharp/Service/Cloud/CeoCompensation/CeoCompensationService.cs
+++ b/IEXSharp/Service/Cloud/CeoCompensation/CeoCompensationService.cs
@@ -10,9 +10,9 @@ namespace IEXSharp.Service.Cloud.CeoCompensation
 	{
 		private readonly ExecutorREST executor;
 
-		public CeoCompensationService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal CeoCompensationService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<CeoCompensationResponse>> CeoCompensationAsync(string symbol) =>

--- a/IEXSharp/Service/Cloud/Commodities/CommoditiesService.cs
+++ b/IEXSharp/Service/Cloud/Commodities/CommoditiesService.cs
@@ -12,9 +12,9 @@ namespace IEXSharp.Service.Cloud.Commodities
 	{
 		private readonly ExecutorREST executor;
 
-		public CommoditiesService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal CommoditiesService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<decimal>> DataPointAsync(CommoditySymbol symbol)

--- a/IEXSharp/Service/Cloud/CorporateActions/CorporateActionsService.cs
+++ b/IEXSharp/Service/Cloud/CorporateActions/CorporateActionsService.cs
@@ -11,11 +11,11 @@ namespace IEXSharp.Service.Cloud.CorporateActions
 {
 	public class CorporateActionsService : ICorporateActionsService
 	{
-		private ExecutorREST executor;
+		private readonly ExecutorREST executor;
 
-		public CorporateActionsService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal CorporateActionsService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<BonusIssueResponse>>> BonusIssueAsync(

--- a/IEXSharp/Service/Cloud/Crypto/CryptoService.cs
+++ b/IEXSharp/Service/Cloud/Crypto/CryptoService.cs
@@ -12,10 +12,10 @@ namespace IEXSharp.Service.Cloud.Crypto
 		private readonly ExecutorREST executor;
 		private readonly ExecutorSSE executorSSE;
 
-		public CryptoService(HttpClient client, string baseSSEURL, string publishableToken, string secretToken, bool sign)
+		public CryptoService(ExecutorREST executor, ExecutorSSE executorSSE)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
-			executorSSE = new ExecutorSSE(baseSSEURL, publishableToken: publishableToken, secretToken: secretToken);
+			this.executor = executor;
+			this.executorSSE = executorSSE;
 		}
 
 		public async Task<IEXResponse<CryptoBookResponse>> BookAsync(string symbol) =>

--- a/IEXSharp/Service/Cloud/EconomicData/EconomicDataService.cs
+++ b/IEXSharp/Service/Cloud/EconomicData/EconomicDataService.cs
@@ -12,9 +12,9 @@ namespace IEXSharp.Service.Cloud.EconomicData
 	{
 		private readonly ExecutorREST executor;
 
-		public EconomicDataService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal EconomicDataService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<decimal>> DataPointAsync(EconomicDataSymbol symbol)

--- a/IEXSharp/Service/Cloud/ForexCurrencies/ForexCurrenciesService.cs
+++ b/IEXSharp/Service/Cloud/ForexCurrencies/ForexCurrenciesService.cs
@@ -12,9 +12,9 @@ namespace IEXSharp.Service.Cloud.ForexCurrencies
 	{
 		private readonly ExecutorREST executor;
 
-		public ForexCurrenciesService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal ForexCurrenciesService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<CurrencyRateResponse>>> LatestRatesAsync(string symbols)

--- a/IEXSharp/Service/Cloud/InvestorsExchangeData/InvestorsExchangeDataService.cs
+++ b/IEXSharp/Service/Cloud/InvestorsExchangeData/InvestorsExchangeDataService.cs
@@ -14,9 +14,9 @@ namespace IEXSharp.Service.Cloud.InvestorsExchangeData
 	{
 		private readonly ExecutorREST executor;
 
-		public InvestorsExchangeDataService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal InvestorsExchangeDataService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<DeepResponse>> DeepAsync(IEnumerable<string> symbols)

--- a/IEXSharp/Service/Cloud/MarketInfo/IMarketInfoService.cs
+++ b/IEXSharp/Service/Cloud/MarketInfo/IMarketInfoService.cs
@@ -70,14 +70,14 @@ namespace IEXSharp.Service.Cloud.MarketInfo
 		/// </summary>
 		/// <param name="symbol"></param>
 		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<UpcomingEarningsResponse>>> UpcomingDividendsAsync(string symbol);
+		Task<IEXResponse<IEnumerable<Dividend>>> UpcomingDividendsAsync(string symbol);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#upcoming-events"/>
 		/// </summary>
 		/// <param name="symbol"></param>
 		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<UpcomingEarningsResponse>>> UpcomingSplitsAsync(string symbol);
+		Task<IEXResponse<IEnumerable<Split>>> UpcomingSplitsAsync(string symbol);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#upcoming-events"/>

--- a/IEXSharp/Service/Cloud/MarketInfo/MarketInfoService.cs
+++ b/IEXSharp/Service/Cloud/MarketInfo/MarketInfoService.cs
@@ -97,17 +97,17 @@ namespace IEXSharp.Service.Cloud.MarketInfo
 
 		public async Task<IEXResponse<IEnumerable<UpcomingEarningsResponse>>> UpcomingEarningsAsync(string symbol)
 		{
-			return await UpcomingEventTypeAsync(symbol, UpcomingEventType.Earnings);
+			return await UpcomingEventTypeAsync<UpcomingEarningsResponse>(symbol, UpcomingEventType.Earnings);
 		}
 
-		public async Task<IEXResponse<IEnumerable<UpcomingEarningsResponse>>> UpcomingDividendsAsync(string symbol)
+		public async Task<IEXResponse<IEnumerable<Dividend>>> UpcomingDividendsAsync(string symbol)
 		{
-			return await UpcomingEventTypeAsync(symbol, UpcomingEventType.Dividends);
+			return await UpcomingEventTypeAsync<Dividend>(symbol, UpcomingEventType.Dividends);
 		}
 
-		public async Task<IEXResponse<IEnumerable<UpcomingEarningsResponse>>> UpcomingSplitsAsync(string symbol)
+		public async Task<IEXResponse<IEnumerable<Split>>> UpcomingSplitsAsync(string symbol)
 		{
-			return await UpcomingEventTypeAsync(symbol, UpcomingEventType.Splits);
+			return await UpcomingEventTypeAsync<Split>(symbol, UpcomingEventType.Splits);
 		}
 
 		public async Task<IEXResponse<IPOCalendarResponse>> UpcomingIposAsync(string symbol)
@@ -128,7 +128,7 @@ namespace IEXSharp.Service.Cloud.MarketInfo
 			return await executor.ExecuteAsync<IPOCalendarResponse>(urlPattern, pathNvc, qsb);
 		}
 
-		private async Task<IEXResponse<IEnumerable<UpcomingEarningsResponse>>> UpcomingEventTypeAsync(string symbol, UpcomingEventType eventType)
+		private async Task<IEXResponse<IEnumerable<T>>> UpcomingEventTypeAsync<T>(string symbol, UpcomingEventType eventType)
 		{
 			string urlPattern = "stock/[symbol]/upcoming-[type]";
 			var qsb = new QueryStringBuilder();
@@ -143,7 +143,7 @@ namespace IEXSharp.Service.Cloud.MarketInfo
 				pathNvc.Add("symbol", symbol);
 			}
 
-			return await executor.ExecuteAsync<IEnumerable<UpcomingEarningsResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<T>>(urlPattern, pathNvc, qsb);
 		}
 	}
 }

--- a/IEXSharp/Service/Cloud/MarketInfo/MarketInfoService.cs
+++ b/IEXSharp/Service/Cloud/MarketInfo/MarketInfoService.cs
@@ -15,9 +15,9 @@ namespace IEXSharp.Service.Cloud.MarketInfo
 	{
 		private readonly ExecutorREST executor;
 
-		public MarketInfoService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal MarketInfoService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<Quote>>> CollectionsAsync(CollectionType collection,

--- a/IEXSharp/Service/Cloud/News/NewsService.cs
+++ b/IEXSharp/Service/Cloud/News/NewsService.cs
@@ -14,10 +14,10 @@ namespace IEXSharp.Service.Cloud.News
 		private readonly ExecutorREST executor;
 		private readonly ExecutorSSE executorSSE;
 
-		public NewsService(HttpClient client, string baseSSEURL, string publishableToken, string secretToken, bool sign)
+		internal NewsService(ExecutorREST executor, ExecutorSSE executorSSE)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
-			executorSSE = new ExecutorSSE(baseSSEURL, publishableToken: publishableToken, secretToken: secretToken);
+			this.executor = executor;
+			this.executorSSE = executorSSE;
 		}
 
 		public async Task<IEXResponse<IEnumerable<NewsResponse>>> NewsAsync(string symbol) =>

--- a/IEXSharp/Service/Cloud/Options/OptionsService.cs
+++ b/IEXSharp/Service/Cloud/Options/OptionsService.cs
@@ -13,9 +13,9 @@ namespace IEXSharp.Service.Cloud.Options
 	{
 		private readonly ExecutorREST executor;
 
-		public OptionsService(HttpClient client, string secretToken, string publishableToken, bool sign)
+		internal OptionsService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<string>>> OptionsAsync(string symbol) =>
@@ -27,7 +27,7 @@ namespace IEXSharp.Service.Cloud.Options
 
 			var qsb = new QueryStringBuilder();
 			var pathNvc = new NameValueCollection { { "symbol", symbol }, { "expiration", expiration } };
-			
+
 			return await executor.ExecuteAsync<IEnumerable<OptionResponse>>(urlPattern, pathNvc, qsb);
 		}
 

--- a/IEXSharp/Service/Cloud/ReferenceData/ReferenceDataService.cs
+++ b/IEXSharp/Service/Cloud/ReferenceData/ReferenceDataService.cs
@@ -12,11 +12,11 @@ namespace IEXSharp.Service.Cloud.ReferenceData
 {
 	internal class ReferenceDataService : IReferenceDataService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
-		public ReferenceDataService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal ReferenceDataService(ExecutorREST executor)
 		{
-			_executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<SearchResponse>>> SearchAsync(string fragment)
@@ -28,17 +28,17 @@ namespace IEXSharp.Service.Cloud.ReferenceData
 				{"fragment", fragment},
 			};
 
-			return await _executor.ExecuteAsync<IEnumerable<SearchResponse>>(urlPattern, pathNvc, null);
+			return await executor.ExecuteAsync<IEnumerable<SearchResponse>>(urlPattern, pathNvc, null);
 		}
 
 		public async Task<IEXResponse<SymbolFXResponse>> SymbolFXAsync() =>
-			await _executor.NoParamExecute<SymbolFXResponse>("ref-data/fx/symbols");
+			await executor.NoParamExecute<SymbolFXResponse>("ref-data/fx/symbols");
 
 		public async Task<IEXResponse<IEnumerable<SymbolCryptoResponse>>> SymbolCryptoAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SymbolCryptoResponse>>("ref-data/crypto/symbols");
+			await executor.NoParamExecute<IEnumerable<SymbolCryptoResponse>>("ref-data/crypto/symbols");
 
 		public async Task<IEXResponse<IEnumerable<SymbolIEXResponse>>> SymbolsIEXAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SymbolIEXResponse>>("ref-data/iex/symbols");
+			await executor.NoParamExecute<IEnumerable<SymbolIEXResponse>>("ref-data/iex/symbols");
 
 		public async Task<IEXResponse<IEnumerable<SymbolInternationalResponse>>> SymbolsInternationalRegionAsync(string region)
 		{
@@ -51,7 +51,7 @@ namespace IEXSharp.Service.Cloud.ReferenceData
 				{"region", region}
 			};
 
-			return await _executor.ExecuteAsync<IEnumerable<SymbolInternationalResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<SymbolInternationalResponse>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<IEnumerable<SymbolInternationalResponse>>> SymbolsInternationalExchangeAsync(string exchange)
@@ -65,32 +65,32 @@ namespace IEXSharp.Service.Cloud.ReferenceData
 				{"exchange", exchange}
 			};
 
-			return await _executor.ExecuteAsync<IEnumerable<SymbolInternationalResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<SymbolInternationalResponse>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<IEnumerable<ExchangeInternationalResponse>>> ExchangeInternationalAsync() =>
-			await _executor.NoParamExecute<IEnumerable<ExchangeInternationalResponse>>("ref-data/exchanges");
+			await executor.NoParamExecute<IEnumerable<ExchangeInternationalResponse>>("ref-data/exchanges");
 
 		public async Task<IEXResponse<IEnumerable<SymbolMutualFundResponse>>> SymbolsMutualFundAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SymbolMutualFundResponse>>("ref-data/mutual-funds/symbols");
+			await executor.NoParamExecute<IEnumerable<SymbolMutualFundResponse>>("ref-data/mutual-funds/symbols");
 
 		public async Task<IEXResponse<Dictionary<string, string[]>>> SymbolsOptionsAsync() =>
-			await _executor.NoParamExecute<Dictionary<string, string[]>>("ref-data/options/symbols");
+			await executor.NoParamExecute<Dictionary<string, string[]>>("ref-data/options/symbols");
 
 		public async Task<IEXResponse<IEnumerable<SymbolOTCResponse>>> SymbolsOTCAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SymbolOTCResponse>>("ref-data/otc/symbols");
+			await executor.NoParamExecute<IEnumerable<SymbolOTCResponse>>("ref-data/otc/symbols");
 
 		public async Task<IEXResponse<IEnumerable<SectorResponse>>> SectorsAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SectorResponse>>("ref-data/sectors");
+			await executor.NoParamExecute<IEnumerable<SectorResponse>>("ref-data/sectors");
 
 		public async Task<IEXResponse<IEnumerable<SymbolResponse>>> SymbolsAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SymbolResponse>>("ref-data/symbols");
+			await executor.NoParamExecute<IEnumerable<SymbolResponse>>("ref-data/symbols");
 
 		public async Task<IEXResponse<IEnumerable<TagResponse>>> TagsAsync() =>
-			await _executor.NoParamExecute<IEnumerable<TagResponse>>("ref-data/tags");
+			await executor.NoParamExecute<IEnumerable<TagResponse>>("ref-data/tags");
 
 		public async Task<IEXResponse<IEnumerable<ExchangeUSResponse>>> ExchangeUSAsync() =>
-			await _executor.NoParamExecute<IEnumerable<ExchangeUSResponse>>("ref-data/market/us/exchanges");
+			await executor.NoParamExecute<IEnumerable<ExchangeUSResponse>>("ref-data/market/us/exchanges");
 
 		public async Task<IEXResponse<IEnumerable<HolidaysAndTradingDatesUSResponse>>> HolidaysAndTradingDatesUSAsync(
 			DateType type, DirectionType direction = DirectionType.Next, int last = 1, DateTime? startDate = null)
@@ -107,7 +107,7 @@ namespace IEXSharp.Service.Cloud.ReferenceData
 				{"startDate", startDate == null ? DateTime.Now.ToString("yyyyMMdd") : ((DateTime) startDate).ToString("yyyyMMdd")}
 			};
 
-			return await _executor.ExecuteAsync<IEnumerable<HolidaysAndTradingDatesUSResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<HolidaysAndTradingDatesUSResponse>>(urlPattern, pathNvc, qsb);
 		}
 	}
 }

--- a/IEXSharp/Service/Cloud/SocialSentiment/SocialSentimentService.cs
+++ b/IEXSharp/Service/Cloud/SocialSentiment/SocialSentimentService.cs
@@ -10,13 +10,13 @@ namespace IEXSharp.Service.Cloud.SocialSentiment
 {
 	public class SocialSentimentService : ISocialSentimentService
 	{
-		private readonly ExecutorSSE executorSSE;
 		private readonly ExecutorREST executor;
+		private readonly ExecutorSSE executorSSE;
 
-		public SocialSentimentService(HttpClient client, string baseSSEURL, string publishableToken, string secretToken, bool sign)
+		internal SocialSentimentService(ExecutorREST executor, ExecutorSSE executorSSE)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
-			executorSSE = new ExecutorSSE(baseSSEURL, publishableToken: publishableToken, secretToken: secretToken);
+			this.executor = executor;
+			this.executorSSE = executorSSE;
 		}
 
 		public SSEClient<SentimentResponse> SubscribeToSentiment(IEnumerable<string> symbols) =>

--- a/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
+++ b/IEXSharp/Service/Cloud/StockFundamentals/StockFundamentalsService.cs
@@ -14,9 +14,9 @@ namespace IEXSharp.Service.Cloud.StockFundamentals
 	{
 		private readonly ExecutorREST executor;
 
-		public StockFundamentalsService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal StockFundamentalsService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<BalanceSheetResponse>> BalanceSheetAsync(string symbol, Period period = Period.Quarter,

--- a/IEXSharp/Service/Cloud/StockPrices/StockPricesService.cs
+++ b/IEXSharp/Service/Cloud/StockPrices/StockPricesService.cs
@@ -16,11 +16,12 @@ namespace IEXSharp.Service.Cloud.StockPrices
 		private readonly ExecutorREST executor;
 		private readonly ExecutorSSE executorSSE;
 
-		public StockPricesService(HttpClient client, string baseSSEURL, string publishableToken, string secretToken, bool sign)
+		internal StockPricesService(ExecutorREST executor, ExecutorSSE executorSSE)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
-			executorSSE = new ExecutorSSE(baseSSEURL, publishableToken: publishableToken, secretToken: secretToken);
+			this.executor = executor;
+			this.executorSSE = executorSSE;
 		}
+
 		public async Task<IEXResponse<BookResponse>> BookAsync(string symbol) =>
 			await executor.SymbolExecuteAsync<BookResponse>("stock/[symbol]/book", symbol);
 

--- a/IEXSharp/Service/Cloud/StockProfiles/StockProfilesService.cs
+++ b/IEXSharp/Service/Cloud/StockProfiles/StockProfilesService.cs
@@ -11,9 +11,9 @@ namespace IEXSharp.Service.Cloud.StockProfiles
 	{
 		private readonly ExecutorREST executor;
 
-		public StockProfilesService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal StockProfilesService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<CompanyResponse>> CompanyAsync(string symbol) =>

--- a/IEXSharp/Service/Cloud/StockResearch/StockResearchService.cs
+++ b/IEXSharp/Service/Cloud/StockResearch/StockResearchService.cs
@@ -13,9 +13,9 @@ namespace IEXSharp.Service.Cloud.StockResearch
 	{
 		private readonly ExecutorREST executor;
 
-		public StockResearchService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal StockResearchService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<AdvancedStatsResponse>> AdvancedStatsAsync(string symbol) =>

--- a/IEXSharp/Service/Cloud/Treasuries/TreasuriesService.cs
+++ b/IEXSharp/Service/Cloud/Treasuries/TreasuriesService.cs
@@ -12,9 +12,9 @@ namespace IEXSharp.Service.Cloud.Treasuries
 	{
 		private readonly ExecutorREST executor;
 
-		public TreasuriesService(HttpClient client, string publishableToken, string secretToken, bool sign)
+		internal TreasuriesService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, publishableToken, secretToken, sign);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<decimal>> DataPointAsync(TreasuryRateSymbol symbol)

--- a/IEXSharp/Service/Legacy/Market/MarketService.cs
+++ b/IEXSharp/Service/Legacy/Market/MarketService.cs
@@ -14,24 +14,24 @@ namespace IEXSharp.Service.Legacy.Market
 {
 	internal class MarketService : IMarketService
 	{
-		private ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
-		public MarketService(HttpClient client)
+		internal MarketService(ExecutorREST executor)
 		{
-			_executor = new ExecutorREST(client, "", "", false);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<TOPSResponse>>> TOPSAsync(IEnumerable<string> symbols)
 		{
 			if (symbols.Count() > 0)
 			{
-				return await _executor.SymbolsExecuteAsync<IEnumerable<TOPSResponse>>("tops", symbols);
+				return await executor.SymbolsExecuteAsync<IEnumerable<TOPSResponse>>("tops", symbols);
 			}
-			return await _executor.NoParamExecute<IEnumerable<TOPSResponse>>("tops");
+			return await executor.NoParamExecute<IEnumerable<TOPSResponse>>("tops");
 		}
 
 		public async Task<IEXResponse<IEnumerable<LastResponse>>> LastAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<IEnumerable<LastResponse>>("tops/last", symbols);
+			=> await executor.SymbolsExecuteAsync<IEnumerable<LastResponse>>("tops/last", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, IEnumerable<HISTResponse>>>> HISTAsync()
 		{
@@ -41,7 +41,7 @@ namespace IEXSharp.Service.Legacy.Market
 
 			var pathNvc = new NameValueCollection();
 
-			return await _executor.ExecuteAsync<Dictionary<string, IEnumerable<HISTResponse>>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<Dictionary<string, IEnumerable<HISTResponse>>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<IEnumerable<HISTResponse>>> HISTByDateAsync(DateTime date)
@@ -53,42 +53,42 @@ namespace IEXSharp.Service.Legacy.Market
 
 			var pathNvc = new NameValueCollection();
 
-			return await _executor.ExecuteAsync<IEnumerable<HISTResponse>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<HISTResponse>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<DeepResponse>> DeepAsync(IEnumerable<string> symbols)
-		   => await _executor.SymbolsExecuteAsync<DeepResponse>("deep", symbols);
+		   => await executor.SymbolsExecuteAsync<DeepResponse>("deep", symbols);
 
 		public async Task<IEXResponse<DeepBookResponse>> DeepBookAsync(IEnumerable<string> symbols)
-		   => await _executor.SymbolsExecuteAsync<DeepBookResponse>("deep/book", symbols);
+		   => await executor.SymbolsExecuteAsync<DeepBookResponse>("deep/book", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, IEnumerable<DeepTradeResponse>>>> DeepTradeAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades", symbols);
 
 		public async Task<IEXResponse<DeepSystemEventResponse>> DeepSystemEventAsync()
-			=> await _executor.NoParamExecute<DeepSystemEventResponse>("deep/system-event");
+			=> await executor.NoParamExecute<DeepSystemEventResponse>("deep/system-event");
 
 		public async Task<IEXResponse<Dictionary<string, DeepTradingStatusResponse>>> DeepTradingStatusAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepTradingStatusResponse>>("deep/trades-status", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepTradingStatusResponse>>("deep/trades-status", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepOperationalHaltStatusResponse>>> DeepOperationHaltStatusAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepOperationalHaltStatusResponse>>("deep/op-halt-status", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepOperationalHaltStatusResponse>>("deep/op-halt-status", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepShortSalePriceTestStatusResponse>>> DeepShortSalePriceTestStatusAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepShortSalePriceTestStatusResponse>>("deep/ssr-status", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepShortSalePriceTestStatusResponse>>("deep/ssr-status", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepSecurityEventResponse>>> DeepSecurityEventAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepSecurityEventResponse>>("deep/security-event", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepSecurityEventResponse>>("deep/security-event", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, IEnumerable<DeepTradeResponse>>>> DeepTradeBreaksAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades-breaks", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, IEnumerable<DeepTradeResponse>>>("deep/trades-breaks", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepAuctionResponse>>> DeepAuctionAsync(IEnumerable<string> symbols)
-		  => await _executor.SymbolsExecuteAsync<Dictionary<string, DeepAuctionResponse>>("deep/auction", symbols);
+		  => await executor.SymbolsExecuteAsync<Dictionary<string, DeepAuctionResponse>>("deep/auction", symbols);
 
 		public async Task<IEXResponse<Dictionary<string, DeepOfficialPriceResponse>>> DeepOfficialPriceAsync(IEnumerable<string> symbols)
-			=> await _executor.SymbolsExecuteAsync<Dictionary<string, DeepOfficialPriceResponse>>("deep/official-price", symbols);
+			=> await executor.SymbolsExecuteAsync<Dictionary<string, DeepOfficialPriceResponse>>("deep/official-price", symbols);
 		public async Task<IEXResponse<IEnumerable<MarketVolumeUSResponse>>> MarketVolumeUSAsync() =>
-			await _executor.NoParamExecute<IEnumerable<MarketVolumeUSResponse>>("market");
+			await executor.NoParamExecute<IEnumerable<MarketVolumeUSResponse>>("market");
 	}
 }

--- a/IEXSharp/Service/Legacy/ReferenceData/ReferenceDataService.cs
+++ b/IEXSharp/Service/Legacy/ReferenceData/ReferenceDataService.cs
@@ -9,26 +9,26 @@ namespace IEXSharp.Service.Legacy.ReferenceData
 {
 	internal class ReferenceDataService : IReferenceDataService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
-		public ReferenceDataService(HttpClient client)
+		internal ReferenceDataService(ExecutorREST executor)
 		{
-			_executor = new ExecutorREST(client, "", "", false);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<IEnumerable<SymbolResponse>>> SymbolsAsync() =>
-			await _executor.NoParamExecute<IEnumerable<SymbolResponse>>("ref-data/symbols");
+			await executor.NoParamExecute<IEnumerable<SymbolResponse>>("ref-data/symbols");
 
 		public async Task<IEXResponse<IEnumerable<IEXCorporateActionsResponse>>> IEXCorporateActionsAsync() =>
-			await _executor.NoParamExecute<IEnumerable<IEXCorporateActionsResponse>>("ref-data/daily-list/corporate-actions");
+			await executor.NoParamExecute<IEnumerable<IEXCorporateActionsResponse>>("ref-data/daily-list/corporate-actions");
 
 		public async Task<IEXResponse<IEnumerable<IEXDividendsResponse>>> IEXDividentsAsync() =>
-			await _executor.NoParamExecute<IEnumerable<IEXDividendsResponse>>("ref-data/daily-list/dividends");
+			await executor.NoParamExecute<IEnumerable<IEXDividendsResponse>>("ref-data/daily-list/dividends");
 
 		public async Task<IEXResponse<IEnumerable<IEXListedSymbolDirectoryResponse>>> IEXListedSymbolDirectoryAsync() =>
-			await _executor.NoParamExecute<IEnumerable<IEXListedSymbolDirectoryResponse>>("ref-data/daily-list/symbol-directory");
+			await executor.NoParamExecute<IEnumerable<IEXListedSymbolDirectoryResponse>>("ref-data/daily-list/symbol-directory");
 
 		public async Task<IEXResponse<IEnumerable<IEXNextDayExDateResponse>>> IEXNextDayExDateAsync() =>
-			await _executor.NoParamExecute<IEnumerable<IEXNextDayExDateResponse>>("ref-data/daily-list/next-day-ex-date");
+			await executor.NoParamExecute<IEnumerable<IEXNextDayExDateResponse>>("ref-data/daily-list/next-day-ex-date");
 	}
 }

--- a/IEXSharp/Service/Legacy/Stats/StatsService.cs
+++ b/IEXSharp/Service/Legacy/Stats/StatsService.cs
@@ -11,11 +11,11 @@ namespace IEXSharp.Service.Legacy.Stats
 {
 	internal class StatsService : IStatsService
 	{
-		private ExecutorREST executor;
+		private readonly ExecutorREST executor;
 
-		public StatsService(HttpClient client)
+		internal StatsService(ExecutorREST executor)
 		{
-			executor = new ExecutorREST(client, "", "", false);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<StatsIntradayResponse>> StatsIntradayAsync() =>

--- a/IEXSharp/Service/Legacy/Stock/StockService.cs
+++ b/IEXSharp/Service/Legacy/Stock/StockService.cs
@@ -20,11 +20,11 @@ namespace IEXSharp.Service.Legacy.Stock
 {
 	internal class StockService : IStockService
 	{
-		private readonly ExecutorREST _executor;
+		private readonly ExecutorREST executor;
 
-		public StockService(HttpClient client)
+		internal StockService(ExecutorREST executor)
 		{
-			_executor = new ExecutorREST(client, string.Empty, string.Empty, false);
+			this.executor = executor;
 		}
 
 		public async Task<IEXResponse<BatchBySymbolLegacyResponse>> BatchBySymbolAsync(string symbol, IEnumerable<BatchType> types,
@@ -71,11 +71,11 @@ namespace IEXSharp.Service.Legacy.Stock
 
 			var pathNvc = new NameValueCollection { { "symbol", symbol } };
 
-			return await _executor.ExecuteAsync<BatchBySymbolLegacyResponse>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<BatchBySymbolLegacyResponse>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<BookResponse>> BookAsync(string symbol) =>
-			await _executor.SymbolExecuteAsync<BookResponse>("stock/[symbol]/book", symbol);
+			await executor.SymbolExecuteAsync<BookResponse>("stock/[symbol]/book", symbol);
 
 		public async Task<IEXResponse<IEnumerable<DividendV1Response>>> DividendAsync(string symbol, DividendRange range)
 		{
@@ -86,11 +86,11 @@ namespace IEXSharp.Service.Legacy.Stock
 				{"symbol", symbol}, {"range", range.GetDescriptionFromEnum()}
 			};
 
-			return await _executor.ExecuteAsync<IEnumerable<DividendV1Response>>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IEnumerable<DividendV1Response>>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<IEnumerable<EffectiveSpreadResponse>>> EffectiveSpreadAsync(string symbol) =>
-			await _executor.SymbolExecuteAsync<IEnumerable<EffectiveSpreadResponse>>(
+			await executor.SymbolExecuteAsync<IEnumerable<EffectiveSpreadResponse>>(
 				"stock/[symbol]/effective-spread", symbol);
 
 		public async Task<IEXResponse<IPOCalendarResponse>> IPOCalendarAsync(IPOType ipoType)
@@ -99,13 +99,13 @@ namespace IEXSharp.Service.Legacy.Stock
 			var qsb = new QueryStringBuilder();
 			var pathNvc = new NameValueCollection { { "ipoType", ipoType.GetDescriptionFromEnum() } };
 
-			return await _executor.ExecuteAsync<IPOCalendarResponse>(urlPattern, pathNvc, qsb);
+			return await executor.ExecuteAsync<IPOCalendarResponse>(urlPattern, pathNvc, qsb);
 		}
 
 		public async Task<IEXResponse<LogoResponse>> LogoAsync(string symbol) =>
-			await _executor.SymbolExecuteAsync<LogoResponse>("stock/[symbol]/logo", symbol);
+			await executor.SymbolExecuteAsync<LogoResponse>("stock/[symbol]/logo", symbol);
 
 		public async Task<IEXResponse<OHLCResponse>> OHLCAsync(string symbol) =>
-			await _executor.SymbolExecuteAsync<OHLCResponse>("stock/[symbol]/ohlc", symbol);
+			await executor.SymbolExecuteAsync<OHLCResponse>("stock/[symbol]/ohlc", symbol);
 	}
 }

--- a/IEXSharpTest/Cloud/MarketInfoTest.cs
+++ b/IEXSharpTest/Cloud/MarketInfoTest.cs
@@ -3,6 +3,8 @@ using IEXSharp.Model.MarketInfo.Request;
 using NUnit.Framework;
 using System.Linq;
 using System.Threading.Tasks;
+using IEXSharpTest.Helper;
+using Newtonsoft.Json;
 
 namespace IEXSharpTest.Cloud
 {
@@ -13,7 +15,10 @@ namespace IEXSharpTest.Cloud
 		[SetUp]
 		public void Setup()
 		{
-			sandBoxClient = new IEXCloudClient(publishableToken: TestGlobal.publishableToken, secretToken: TestGlobal.secretToken, signRequest: false, useSandBox: true);
+			sandBoxClient = new IEXCloudClientForTest(publishableToken: TestGlobal.publishableToken, secretToken: TestGlobal.secretToken, signRequest: false, useSandBox: true)
+			{
+				JsonMissingMemberHandling = MissingMemberHandling.Error
+			};
 		}
 
 		[Test]
@@ -144,7 +149,7 @@ namespace IEXSharpTest.Cloud
 
 		[Test]
 		[TestCase("")]
-		[TestCase("AAPL")]
+		[TestCase("market")]
 		public async Task UpcomingDividendsAsyncTest(string symbol)
 		{
 			var response = await sandBoxClient.MarketInfoService.UpcomingDividendsAsync(symbol);
@@ -154,7 +159,7 @@ namespace IEXSharpTest.Cloud
 
 			var data = response.Data.First();
 			Assert.NotNull(data.symbol);
-			Assert.NotNull(data.reportDate);
+			Assert.NotNull(data.exDate);
 		}
 
 		[Test]
@@ -172,7 +177,7 @@ namespace IEXSharpTest.Cloud
 
 			var data = response.Data.First();
 			Assert.NotNull(data.symbol);
-			Assert.NotNull(data.reportDate);
+			Assert.NotNull(data.exDate);
 		}
 
 		[Test]

--- a/IEXSharpTest/Cloud/ReferenceDataTest.cs
+++ b/IEXSharpTest/Cloud/ReferenceDataTest.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using IEXSharp;
 using IEXSharp.Model.ReferenceData.Request;
+using IEXSharpTest.Helper;
+using Newtonsoft.Json;
 
 namespace IEXSharpTest.Cloud
 {
@@ -14,7 +16,10 @@ namespace IEXSharpTest.Cloud
 		[SetUp]
 		public void Setup()
 		{
-			sandBoxClient = new IEXCloudClient(TestGlobal.publishableToken, TestGlobal.secretToken, false, true);
+			sandBoxClient = new IEXCloudClientForTest(TestGlobal.publishableToken, TestGlobal.secretToken, false, true)
+			{
+				JsonMissingMemberHandling = MissingMemberHandling.Error
+			};
 		}
 
 		[Test]

--- a/IEXSharpTest/Cloud/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/StockFundamentalsTest.cs
@@ -5,6 +5,8 @@ using IEXSharp;
 using IEXSharp.Model.Shared.Request;
 using IEXSharp.Model.StockFundamentals.Request;
 using System;
+using IEXSharpTest.Helper;
+using Newtonsoft.Json;
 
 namespace IEXSharpTest.Cloud
 {
@@ -15,7 +17,10 @@ namespace IEXSharpTest.Cloud
 		[SetUp]
 		public void Setup()
 		{
-			sandBoxClient = new IEXCloudClient(TestGlobal.publishableToken, TestGlobal.secretToken, false, true);
+			sandBoxClient = new IEXCloudClientForTest(TestGlobal.publishableToken, TestGlobal.secretToken, false, true)
+			{
+				JsonMissingMemberHandling = MissingMemberHandling.Error
+			};
 		}
 
 		[Test]

--- a/IEXSharpTest/Helper/IEXCloudClientForTest.cs
+++ b/IEXSharpTest/Helper/IEXCloudClientForTest.cs
@@ -1,0 +1,18 @@
+using IEXSharp;
+using Newtonsoft.Json;
+
+namespace IEXSharpTest.Helper
+{
+	public class IEXCloudClientForTest : IEXCloudClient
+	{
+		public IEXCloudClientForTest(string publishableToken, string secretToken, bool signRequest, bool useSandBox, APIVersion version = APIVersion.stable) : base(publishableToken, secretToken, signRequest, useSandBox, version)
+		{
+		}
+
+		public MissingMemberHandling JsonMissingMemberHandling
+		{
+			get => executor.JsonSerializerSettings.MissingMemberHandling;
+			set => executor.JsonSerializerSettings.MissingMemberHandling = value;
+		}
+	}
+}


### PR DESCRIPTION
Hello Victor,

Actually we can't verify if our Json Object match the contracts exposed by the IEXCloud Api,
I just added a way to detect missing json properties on our side.

I Exposed ExecutorREST.JsonSerializerSettings to UnitTests and made them override JsonMissingMemberHandling through IEXCloudClientForTest

For that I moved ExecutorREST and ExecutorSSE initialization from Services to IEXCloudClient & IEXLegacyClient

This work is done for IMarketInfoService and IStockFundamentalsService for the moment,
maybe we can also use the new IEXCloudClientForTest for other services tests and make them fail on purpose.

Please leave me a comment if you have any suggestions or concerns :)
Thanks