### PR TITLE
Wall Street Horizon Tests and Share Holder Meetings 

### DIFF
--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/CompanyTravelResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/CompanyTravelResponse.cs
@@ -1,0 +1,25 @@
+namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
+{
+	public class CompanyTravelResponse
+	{
+		public string additionalInfoUrl { get; set; }
+		public string companyName { get; set; }
+		public string endDate { get; set; }
+		public string eventDesc { get; set; }
+		public string eventId { get; set; }
+		public string eventStatus { get; set; }
+		public string organizer { get; set; }
+		public string purl { get; set; }
+		public string sectorNames { get; set; }
+		public string startDate { get; set; }
+		public string symbol { get; set; }
+		public string timeZone { get; set; }
+		public string updated { get; set; }
+		public string venueCountry { get; set; }
+		public string venueCountryIso { get; set; }
+		public string id { get; set; }
+		public string source { get; set; }
+		public string key { get; set; }
+		public string subkey { get; set; }
+	}
+}

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/HolidaysResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/HolidaysResponse.cs
@@ -6,7 +6,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string eventdate { get; set; }
 		public string eventday { get; set; }
 		public string eventname { get; set; }
-		public string earlyclosetime { get; set; }
+		public object earlyclosetime { get; set; }
 		public string countrycode { get; set; }
 		public string financialcentername { get; set; }
 		public string updated { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/LegalActionsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/LegalActionsResponse.cs
@@ -16,7 +16,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string contactphone { get; set; }
 		public string lawfirmhomepage { get; set; }
 		public long classperiodbegin { get; set; }
-		public long motiondeadline { get; set; }
+		public object motiondeadline { get; set; }
 		public long classperiodend { get; set; }
 		public string prurl { get; set; }
 		public string stage { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/MergersAndAcquisitionsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/MergersAndAcquisitionsResponse.cs
@@ -1,0 +1,27 @@
+namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
+{
+	public class MergersAndAcquisitionsResponse
+	{
+		public string acquirerCompanyId { get; set; }
+		public string acquirerName { get; set; }
+		public string acquirerSymbol { get; set; }
+		public string actionNotes { get; set; }
+		public string actionStatus { get; set; }
+		public string actionType { get; set; }
+		public string announceDate { get; set; }
+		public string closeDate { get; set; }
+		public string etFlag { get; set; }
+		public string eventId { get; set; }
+		public string newsReferences { get; set; }
+		public string purchasePriceSharesNumber { get; set; }
+		public string srFlag  { get; set; }
+		public string targetCompanyId { get; set; }
+		public string targetName { get; set; }
+		public string targetSymbol { get; set; }
+		public string updated { get; set; }
+		public string id { get; set; }
+		public string source { get; set; }
+		public string key { get; set; }
+		public string subkey  { get; set; }
+	}
+}

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/ShareHolderMeetingsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/ShareHolderMeetingsResponse.cs
@@ -20,7 +20,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string purl { get; set; }
 		public string shmdistance { get; set; }
 		public string referencelink { get; set; }
-		public double shmmeetingtype { get; set; }
+		public object shmmeetingtype { get; set; }
 		public string updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonEventResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonEventResponse.cs
@@ -10,20 +10,20 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
         public string sectornames { get; set; }
         public string startdate { get; set; }
         public string enddate { get; set; }
-        public string localtimestart { get; set; }
+        public object localtimestart { get; set; }
         public string timezone { get; set; }
-        public string venue { get; set; }
-        public string venueaddress { get; set; }
+        public object venue { get; set; }
+        public object venueaddress { get; set; }
         public string venuecity { get; set; }
         public string venuestate { get; set; }
         public string venuecountry { get; set; }
         public string venuecountryiso { get; set; }
         public string purl { get; set; }
-        public string inviteurl { get; set; }
-        public string scheduleurl { get; set; }
-        public string additionalinfourl { get; set; }
-        public string externalnote { get; set; }
-        public string referencelink { get; set; }
+        public object inviteurl { get; set; }
+        public object scheduleurl { get; set; }
+        public object additionalinfourl { get; set; }
+        public object externalnote { get; set; }
+        public object referencelink { get; set; }
         public string updated { get; set; }
         public presenters presenters { get; set; }
         public string symbol { get; set; }
@@ -46,10 +46,10 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
         public string companyname { get; set; }
         public string startdate { get; set; }
         public string enddate { get; set; }
-        public string time { get; set; }
+        public object time { get; set; }
         public string announcedate { get; set; }
         public string presentername { get; set; }
-        public string presentertitle { get; set; }
+        public object presentertitle { get; set; }
         public string created { get; set; }
         public string updated { get; set; }
     }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonEventResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonEventResponse.cs
@@ -15,7 +15,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
         public object venue { get; set; }
         public object venueaddress { get; set; }
         public string venuecity { get; set; }
-        public string venuestate { get; set; }
+        public object venuestate { get; set; }
         public string venuecountry { get; set; }
         public string venuecountryiso { get; set; }
         public string purl { get; set; }

--- a/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/IWallStreetHorizonService.cs
+++ b/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/IWallStreetHorizonService.cs
@@ -113,7 +113,7 @@ namespace IEXSharp.Service.Cloud.PremiumData.WallStreetHorizon
 		/// <param name="symbol">Stock symbol</param>
 		/// <param name="eventId">Event ID</param>
 		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<WallStreetHorizonResponse>>> MergersAndAcquisitionsAsync(string symbol, string eventId);
+		Task<IEXResponse<IEnumerable<MergersAndAcquisitionsResponse>>> MergersAndAcquisitionsAsync(string symbol, string eventId);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#product-events"/>

--- a/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/IWallStreetHorizonService.cs
+++ b/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/IWallStreetHorizonService.cs
@@ -51,7 +51,7 @@ namespace IEXSharp.Service.Cloud.PremiumData.WallStreetHorizon
 		/// <param name="symbol">Stock symbol</param>
 		/// /// <param name="eventId">Event ID</param>
 		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<WallStreetHorizonResponse>>> CompanyTravelAsync(string symbol, string eventId);
+		Task<IEXResponse<IEnumerable<CompanyTravelResponse>>> CompanyTravelAsync(string symbol, string eventId);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#filing-due-dates"/>

--- a/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/WallStreetHorizonService.cs
+++ b/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/WallStreetHorizonService.cs
@@ -85,12 +85,12 @@ namespace IEXSharp.Service.Cloud.PremiumData.WallStreetHorizon
 		public async Task<IEXResponse<IEnumerable<LegalActionsResponse>>> LegalActionsAsync() =>
 			await executor.NoParamExecute<IEnumerable<LegalActionsResponse>>("time-series/PREMIUM_WALLSTREETHORIZON_LEGAL_ACTIONS");
 
-		public async Task<IEXResponse<IEnumerable<WallStreetHorizonResponse>>> MergersAndAcquisitionsAsync(string symbol, string eventId)
+		public async Task<IEXResponse<IEnumerable<MergersAndAcquisitionsResponse>>> MergersAndAcquisitionsAsync(string symbol, string eventId)
 		{
 			const string url = "time-series/PREMIUM_WALLSTREETHORIZON_MERGER_ACQUISITIONS/";
 			var fullUrl = GetWallSymbolEventUrl(url, symbol, eventId);
 
-			return await executor.NoParamExecute<IEnumerable<WallStreetHorizonResponse>>(fullUrl);
+			return await executor.NoParamExecute<IEnumerable<MergersAndAcquisitionsResponse>>(fullUrl);
 		}
 
 		public async Task<IEXResponse<IEnumerable<ProductEventsResponse>>> ProductEventsAsync(string symbol, string eventId)

--- a/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/WallStreetHorizonService.cs
+++ b/IEXSharp/Service/Cloud/PremiumData/WallStreetHorizon/WallStreetHorizonService.cs
@@ -50,12 +50,12 @@ namespace IEXSharp.Service.Cloud.PremiumData.WallStreetHorizon
 		public async Task<IEXResponse<IEnumerable<WallStreetHorizonResponse>>> CapitalMarketsDayAsync() =>
 			await executor.NoParamExecute<IEnumerable<WallStreetHorizonResponse>>("time-series/PREMIUM_WALLSTREETHORIZON_CAPITAL_MARKETS_DAY");
 
-		public async Task<IEXResponse<IEnumerable<WallStreetHorizonResponse>>> CompanyTravelAsync(string symbol, string eventId)
+		public async Task<IEXResponse<IEnumerable<CompanyTravelResponse>>> CompanyTravelAsync(string symbol, string eventId)
 		{
 			const string url = "time-series/PREMIUM_WALLSTREETHORIZON_COMPANY_TRAVEL/";
 			var fullUrl = GetWallSymbolEventUrl(url, symbol, eventId);
 
-			return await executor.NoParamExecute<IEnumerable<WallStreetHorizonResponse>>(fullUrl);
+			return await executor.NoParamExecute<IEnumerable<CompanyTravelResponse>>(fullUrl);
 		}
 
 		public async Task<IEXResponse<IEnumerable<FilingsDueDatesResponse>>> FilingDueDatesAsync() =>

--- a/IEXSharpTest/Cloud/PremiumData/WallStreetHorizonTest.cs
+++ b/IEXSharpTest/Cloud/PremiumData/WallStreetHorizonTest.cs
@@ -82,7 +82,7 @@ namespace IEXSharpTest.Cloud.PremiumData
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
-			Assert.IsNotNull(response.Data.First().venue);
+			Assert.IsNotNull(response.Data.First().companyName);
 		}
 
 		[Test]

--- a/IEXSharpTest/Cloud/PremiumData/WallStreetHorizonTest.cs
+++ b/IEXSharpTest/Cloud/PremiumData/WallStreetHorizonTest.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 
 namespace IEXSharpTest.Cloud.PremiumData
 {
-	[Ignore("Ignored for now. It seems even with Sandbox keys these charge you per call.")]
 	public class WallStreetHorizonTest
 	{
 		private IEXCloudClient sandBoxClient;
@@ -177,7 +176,6 @@ namespace IEXSharpTest.Cloud.PremiumData
 		}
 
 		[Test]
-		[Ignore("Not yet sure of return type - docs are incomplete. It's a IEnumerable<WallStreetHorizonResponse> for now.")]
 		[TestCase("", "")]
 		[TestCase("AAPL", "")]
 		public async Task MergersAndAcquisitionsAsyncTest(string symbol, string eventId)
@@ -186,7 +184,7 @@ namespace IEXSharpTest.Cloud.PremiumData
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
-			Assert.IsNotNull(response.Data.First().eventid);
+			Assert.IsNotNull(response.Data.First().eventId);
 		}
 
 		[Test]


### PR DESCRIPTION
- No longer ignoring Wall Street Horizon tests.
- Got response type for ShareHolderMeeting
- Discovered and fixed broken tests.

Some of the response json had "key": {} and newtonsoft didn't enjoy parsing them. So that's the change from strings > objects in some of the response objects.