### PR TITLE
Updated nullable fields in QuoteSSE to match observed possible null fields

### DIFF
--- a/IEXSharp/Model/Shared/Response/QuoteSSE.cs
+++ b/IEXSharp/Model/Shared/Response/QuoteSSE.cs
@@ -24,11 +24,11 @@ namespace IEXSharp.Model.Shared.Response
 		public string companyName { get; set; }
 		public string primaryExchange { get; set; }
 		public string calculationPrice { get; set; }
-		public decimal open { get; set; }
-		public long openTime { get; set; }
+		public decimal? open { get; set; }
+		public long? openTime { get; set; }
 		public string openSource { get; set; }
-		public decimal close { get; set; }
-		public long closeTime { get; set; }
+		public decimal? close { get; set; }
+		public long? closeTime { get; set; }
 		public string closeSource { get; set; }
 		public decimal high { get; set; }
 		public long highTime { get; set; }
@@ -44,14 +44,14 @@ namespace IEXSharp.Model.Shared.Response
 		public decimal iexRealtimePrice { get; set; }
 		public int iexRealtimeSize { get; set; }
 		public long iexLastUpdated { get; set; }
-		public decimal delayedPrice { get; set; }
-		public long delayedPriceTime { get; set; }
-		public decimal oddLotDelayedPrice { get; set; }
-		public long oddLotDelayedPriceTime { get; set; }
-		public decimal extendedPrice { get; set; }
-		public decimal extendedChange { get; set; }
-		public decimal extendedChangePercent { get; set; }
-		public long extendedPriceTime { get; set; }
+		public decimal? delayedPrice { get; set; }
+		public long? delayedPriceTime { get; set; }
+		public decimal? oddLotDelayedPrice { get; set; }
+		public long? oddLotDelayedPriceTime { get; set; }
+		public decimal? extendedPrice { get; set; }
+		public decimal? extendedChange { get; set; }
+		public decimal? extendedChangePercent { get; set; }
+		public long? extendedPriceTime { get; set; }
 		public decimal previousClose { get; set; }
 		public long previousVolume { get; set; }
 		public decimal change { get; set; }


### PR DESCRIPTION
Was testing out example functionality and could not get the stock ticker for "MVIS" to process without hitting an exception. Going through the stack traces I discovered it was having difficulty with some fields being unexpectedly null.

This change updates the model to reflect the observed nullable fields in the response below.

`[
  {
    "symbol": "MVIS",
    "companyName": "MicroVision, Inc.",
    "primaryExchange": "NASDAQ",
    "calculationPrice": "iexlasttrade",
    "open": null,
    "openTime": null,
    "openSource": "official",
    "close": null,
    "closeTime": null,
    "closeSource": "official",
    "high": 1.56,
    "highTime": 1597355281919,
    "highSource": "15 minute delayed price",
    "low": 1.27,
    "lowTime": 1597325737167,
    "lowSource": "15 minute delayed price",
    "latestPrice": 1.495,
    "latestSource": "IEX Last Trade",
    "latestTime": "August 13, 2020",
    "latestUpdate": 1597348633760,
    "latestVolume": 8984476,
    "iexRealtimePrice": 1.495,
    "iexRealtimeSize": 100,
    "iexLastUpdated": 1597348633760,
    "delayedPrice": null,
    "delayedPriceTime": null,
    "oddLotDelayedPrice": null,
    "oddLotDelayedPriceTime": null,
    "extendedPrice": null,
    "extendedChange": null,
    "extendedChangePercent": null,
    "extendedPriceTime": null,
    "previousClose": 1.42,
    "previousVolume": 8283347,
    "change": 0.075,
    "changePercent": 0.05282,
    "volume": 8984476,
    "iexMarketPercent": 0.008374444987108876,
    "iexVolume": 75240,
    "avgTotalVolume": 14608529,
    "iexBidPrice": 0,
    "iexBidSize": 0,
    "iexAskPrice": 0,
    "iexAskSize": 0,
    "iexOpen": null,
    "iexOpenTime": null,
    "iexClose": 1.495,
    "iexCloseTime": 1597348633760,
    "marketCap": 214454760,
    "peRatio": -11.01,
    "week52High": 3.45,
    "week52Low": 0.153,
    "ytdChange": 0.896976,
    "lastTradeTime": 1597348800327
  }
]`