### PR TITLE
Remove DividendAsync from StockService

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/DividendResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/DividendResponse.cs
@@ -3,8 +3,6 @@ using IEXSharp.Model.Shared.Response;
 
 namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 {
-	public class DividendV1Response : DividendV1 { }
-
 	public class DividendBasicResponse : Dividend
 	{
 		public DateTime date { get; set; }

--- a/IEXSharp/Model/Shared/Response/Dividend.cs
+++ b/IEXSharp/Model/Shared/Response/Dividend.cs
@@ -12,19 +12,6 @@ namespace IEXSharp.Model.Shared.Response
 		quarterly = 2,
 	}
 
-	public class DividendV1
-	{
-		public DateTime exDate { get; set; }
-		public DateTime paymentDate { get; set; }
-		public DateTime recordDate { get; set; }
-		public DateTime declaredDate { get; set; }
-		public decimal amount { get; set; }
-		public string flag { get; set; }
-		public string type { get; set; }
-		public string qualified { get; set; }
-		public decimal indicated { get; set; }
-	}
-
 	public class Dividend
 	{
 		public DateTime exDate { get; set; }

--- a/IEXSharp/Service/Legacy/Stock/IStockService.cs
+++ b/IEXSharp/Service/Legacy/Stock/IStockService.cs
@@ -33,14 +33,6 @@ namespace IEXSharp.Service.Legacy.Stock
 		Task<IEXResponse<BookResponse>> BookAsync(string symbol);
 
 		/// <summary>
-		/// <see cref="https://iextrading.com/developer/docs/#dividends"/>
-		/// </summary>
-		/// <param name="symbol"></param>
-		/// <param name="range"></param>
-		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<DividendV1Response>>> DividendAsync(string symbol, DividendRange range);
-
-		/// <summary>
 		/// <see cref="https://iextrading.com/developer/docs/#effective-spread"/>
 		/// </summary>
 		/// <param name="symbol"></param>

--- a/IEXSharp/Service/Legacy/Stock/StockService.cs
+++ b/IEXSharp/Service/Legacy/Stock/StockService.cs
@@ -76,18 +76,6 @@ namespace IEXSharp.Service.Legacy.Stock
 		public async Task<IEXResponse<BookResponse>> BookAsync(string symbol) =>
 			await executor.SymbolExecuteAsync<BookResponse>("stock/[symbol]/book", symbol);
 
-		public async Task<IEXResponse<IEnumerable<DividendV1Response>>> DividendAsync(string symbol, DividendRange range)
-		{
-			const string urlPattern = "stock/[symbol]/dividends/[range]";
-			var qsb = new QueryStringBuilder();
-			var pathNvc = new NameValueCollection
-			{
-				{"symbol", symbol}, {"range", range.GetDescriptionFromEnum()}
-			};
-
-			return await executor.ExecuteAsync<IEnumerable<DividendV1Response>>(urlPattern, pathNvc, qsb);
-		}
-
 		public async Task<IEXResponse<IEnumerable<EffectiveSpreadResponse>>> EffectiveSpreadAsync(string symbol) =>
 			await executor.SymbolExecuteAsync<IEnumerable<EffectiveSpreadResponse>>(
 				"stock/[symbol]/effective-spread", symbol);

--- a/IEXSharpTest/Legacy/StockTest.cs
+++ b/IEXSharpTest/Legacy/StockTest.cs
@@ -41,22 +41,6 @@ namespace IEXSharpTest.Legacy
 		}
 
 		[Test]
-		[TestCase("AAPL", DividendRange.OneMonth)]
-		[TestCase("AAPL", DividendRange.OneYear)]
-		[TestCase("AAPL", DividendRange.TwoYears)]
-		[TestCase("AAPL", DividendRange.ThreeMonths)]
-		[TestCase("AAPL", DividendRange.FiveYears)]
-		[TestCase("AAPL", DividendRange.SixMonths)]
-		[TestCase("AAPL", DividendRange.Next)]
-		[TestCase("AAPL", DividendRange.Ytd)]
-		public async Task DividendAsyncTest(string symbol, DividendRange range)
-		{
-			var response = await prodClient.Stock.DividendAsync(symbol, range);
-
-			Assert.IsNotNull(response);
-		}
-
-		[Test]
 		[TestCase("AAPL")]
 		[TestCase("FB")]
 		public async Task EffectiveSpreadAsyncTest(string symbol)


### PR DESCRIPTION
Remove DividendAsync from StockService since the same method
is already implemented in StockFundamentalsService.DividendsBasicAsync

The removal of this method is probably been missed in
https://github.com/vslee/IEXSharp/commit/ca5029eb37afe7ac94464bd3d903fd35a63c6f9b