### PR TITLE
Expanded the possible optional parameters in CoreData Batch API

### DIFF
--- a/IEXSharp/Service/Cloud/CoreData/Batch/BatchService.cs
+++ b/IEXSharp/Service/Cloud/CoreData/Batch/BatchService.cs
@@ -21,7 +21,7 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 
 		public async Task<IEXResponse<BatchResponse>>
 			BatchBySymbolAsync(string symbol, IEnumerable<BatchType> types,
-			string range = "", int last = 1)
+			IReadOnlyDictionary<string, string> optionalParameters = null)
 		{
 			if (string.IsNullOrEmpty(symbol))
 			{
@@ -30,6 +30,13 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 			else if (types?.Count() < 1)
 			{
 				throw new ArgumentNullException(nameof(types));
+			}
+
+			if (optionalParameters != null && optionalParameters.ContainsKey("types"))
+			{
+				throw new ArgumentException(
+					paramName: nameof(optionalParameters),
+					message: $"types key in {nameof(optionalParameters)} argument with value \"{optionalParameters["types"]}\" is in conflict with the {nameof(types)} argument. Remove it from the collection");
 			}
 
 			const string urlPattern = "stock/[symbol]/batch";
@@ -42,12 +49,14 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 
 			var qsb = new QueryStringBuilder();
 			qsb.Add("types", string.Join(",", qsType));
-			if (!string.IsNullOrWhiteSpace(range))
-			{
-				qsb.Add("range", range);
-			}
 
-			qsb.Add("last", last);
+			if (optionalParameters != null)
+			{
+				foreach (var parameter in optionalParameters)
+				{
+					qsb.Add(parameter.Key, parameter.Value);
+				}
+			}
 
 			var pathNvc = new NameValueCollection { { "symbol", symbol } };
 
@@ -55,7 +64,7 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 		}
 
 		public async Task<IEXResponse<Dictionary<string, BatchResponse>>> BatchByMarketAsync(IEnumerable<string> symbols,
-			IEnumerable<BatchType> types, string range = "", int last = 1)
+			IEnumerable<BatchType> types, IReadOnlyDictionary<string, string> optionalParameters = null)
 		{
 			if (symbols?.Count() < 1)
 			{
@@ -64,6 +73,20 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 			else if (types?.Count() < 1)
 			{
 				throw new ArgumentNullException("batchTypes cannot be null");
+			}
+
+			if (optionalParameters != null && optionalParameters.ContainsKey("types"))
+			{
+				throw new ArgumentException(
+					paramName: nameof(optionalParameters),
+					message: $"types key in {nameof(optionalParameters)} argument with value \"{optionalParameters["types"]}\" is in conflict with the {nameof(types)} argument. Remove it from the collection");
+			}
+
+			if (optionalParameters != null && optionalParameters.ContainsKey("symbols"))
+			{
+				throw new ArgumentException(
+					paramName: nameof(optionalParameters),
+					message: $"symbols key in {nameof(optionalParameters)} argument with value \"{optionalParameters["symbols"]}\" is in conflict with the {nameof(symbols)} argument. Remove it from the collection");
 			}
 
 			const string urlPattern = "stock/market/batch";
@@ -77,12 +100,14 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 			var qsb = new QueryStringBuilder();
 			qsb.Add("symbols", string.Join(",", symbols));
 			qsb.Add("types", string.Join(",", qsType));
-			if (!string.IsNullOrWhiteSpace(range))
-			{
-				qsb.Add("range", range);
-			}
 
-			qsb.Add("last", last);
+			if (optionalParameters != null)
+			{
+				foreach (var parameter in optionalParameters)
+				{
+					qsb.Add(parameter.Key, parameter.Value);
+				}
+			}
 
 			var pathNvc = new NameValueCollection();
 

--- a/IEXSharp/Service/Cloud/CoreData/Batch/IBatchService.cs
+++ b/IEXSharp/Service/Cloud/CoreData/Batch/IBatchService.cs
@@ -14,19 +14,17 @@ namespace IEXSharp.Service.Cloud.CoreData.Batch
 		/// </summary>
 		/// <param name="symbol"></param>
 		/// <param name="types"></param>
-		/// <param name="range"></param>
-		/// <param name="last"></param>
+		/// <param name="optionalParameters"></param>
 		/// <returns></returns>
-		Task<IEXResponse<BatchResponse>> BatchBySymbolAsync(string symbol, IEnumerable<BatchType> types, string range = "", int last = 1);
+		Task<IEXResponse<BatchResponse>> BatchBySymbolAsync(string symbol, IEnumerable<BatchType> types, IReadOnlyDictionary<string, string> optionalParameters = null);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#batch-requests"/>
 		/// </summary>
 		/// <param name="symbols"></param>
 		/// <param name="types"></param>
-		/// <param name="range"></param>
-		/// <param name="last"></param>
+		/// <param name="optionalParameters"></param>
 		/// <returns></returns>
-		Task<IEXResponse<Dictionary<string, BatchResponse>>> BatchByMarketAsync(IEnumerable<string> symbols, IEnumerable<BatchType> types, string range = "", int last = 1);
+		Task<IEXResponse<Dictionary<string, BatchResponse>>> BatchByMarketAsync(IEnumerable<string> symbols, IEnumerable<BatchType> types, IReadOnlyDictionary<string, string> optionalParameters = null);
 	}
 }

--- a/IEXSharpTest/Cloud/CoreData/BatchTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/BatchTest.cs
@@ -25,7 +25,13 @@ namespace IEXSharpTest.Cloud.CoreData
 		[TestCase("AAPL", new BatchType[] { BatchType.News, BatchType.Quote, BatchType.Chart, BatchType.Price })]
 		public async Task BatchBySymbolAsyncTest(string symbol, IEnumerable<BatchType> types, string range = "", int last = 1)
 		{
-			var response = await sandBoxClient.Batch.BatchBySymbolAsync(symbol, types, range, last);
+			Dictionary<string, string> optionalParameters = new Dictionary<string, string>()
+			{
+				{ "range", range },
+				{ "last", last.ToString() },
+			};
+
+			var response = await sandBoxClient.Batch.BatchBySymbolAsync(symbol, types, optionalParameters);
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
@@ -38,7 +44,13 @@ namespace IEXSharpTest.Cloud.CoreData
 		[TestCase(new string[] { "AAPL" }, new BatchType[] { BatchType.SplitsBasic, BatchType.DividendsBasic })]
 		public async Task BatchByMarketAsyncTest(IEnumerable<string> symbols, IEnumerable<BatchType> types, string range = "", int last = 1)
 		{
-			var response = await sandBoxClient.Batch.BatchByMarketAsync(symbols, types, range, last);
+			Dictionary<string, string> optionalParameters = new Dictionary<string, string>()
+			{
+				{ "range", range },
+				{ "last", last.ToString() },
+			};
+
+			var response = await sandBoxClient.Batch.BatchByMarketAsync(symbols, types, optionalParameters);
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);


### PR DESCRIPTION
Add the correct implementation for the CoreData Batch API. This is done so that  parameters that are sent to individual endpoints can be specified in batch calls and will be applied to each supporting endpoint.

Documentation for the batch API is available at https://www.iexcloud.io/docs/api/#batch-requests