### PR TITLE
Update the batch response properties for the options API

### DIFF
--- a/IEXSharp/Model/CoreData/Batch/Response/BatchResponse.cs
+++ b/IEXSharp/Model/CoreData/Batch/Response/BatchResponse.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using IEXSharp.Model.CoreData.News.Response;
+using IEXSharp.Model.CoreData.Options.Response;
 using IEXSharp.Model.CoreData.StockFundamentals.Response;
 using IEXSharp.Model.CoreData.StockPrices.Response;
 using IEXSharp.Model.CoreData.StockProfiles.Response;
@@ -70,7 +73,34 @@ namespace IEXSharp.Model.CoreData.Batch.Response
 		public LogoResponse Logo { get; set; }
 		public List<NewsResponse> News { get; set; }
 		public OHLCResponse Ohlc { get; set; }
-		public List<string> Options { get; set; }
+
+		[JsonPropertyName("options")]
+		public List<JsonElement> RawOptions { get; set; }
+
+		public List<OptionResponse> OptionContracts
+		{
+			get
+			{
+				return this.RawOptions != null
+					? this.RawOptions
+						.Select(option => JsonSerializer.Deserialize<OptionResponse>(option.GetRawText()))
+						.ToList()
+					: null;
+			}
+		}
+
+		public List<string> OptionExpirationDates
+		{
+			get
+			{
+				return this.RawOptions != null
+					? this.RawOptions
+						.Select(option => option.ToString())
+						.ToList()
+					: null;
+			}
+		}
+
 		public List<string> Peers { get; set; }
 
 		[JsonPropertyName("previous")]


### PR DESCRIPTION
Update the batch response properties for the options API so the batch API is actually useful when working with options data. IEX Cloud API for the options endpoint is available at https://www.iexcloud.io/docs/api/#options

This is a follow up to #68