### PR TITLE
Bugfix: Usage Responses

### DIFF
--- a/IEXSharp/Helper/ExecutorREST.cs
+++ b/IEXSharp/Helper/ExecutorREST.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Polly;
-using Polly.Retry;
 using System.Text.Json;
 
 namespace IEXSharp.Helper

--- a/IEXSharp/Helper/JSONConverters.cs
+++ b/IEXSharp/Helper/JSONConverters.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/IEXSharp/Model/Account/Request/UsageType.cs
+++ b/IEXSharp/Model/Account/Request/UsageType.cs
@@ -10,11 +10,11 @@ namespace IEXSharp.Model.Account.Request
 		Messages,
 		[Description("rules")]
 		Rules,
-		[Description("rulerecords")]
+		[Description("rule-records")]
 		RuleRecords,
 		[Description("alerts")]
 		Alerts,
-		[Description("alertrecords")]
+		[Description("alert-records")]
 		AlertRecords
 	}
 }

--- a/IEXSharp/Model/Account/Response/MessageUsageResponse.cs
+++ b/IEXSharp/Model/Account/Response/MessageUsageResponse.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace IEXSharp.Model.Account.Response
+{
+	public class MessageUsageResponse
+	{
+		public Dictionary<DateTime, string> dailyUsage { get; set; }
+		public long monthlyUsage { get; set; }
+		public long monthlyPayAsYouGo { get; set; }
+		public Dictionary<string, string> tokenUsage { get; set; }
+		public Dictionary<string, string> keyUsage { get; set; }
+	}
+}

--- a/IEXSharp/Model/Account/Response/UsageResponse.cs
+++ b/IEXSharp/Model/Account/Response/UsageResponse.cs
@@ -13,17 +13,8 @@ namespace IEXSharp.Model.Account.Response
 	{
 		public long monthlyUsage { get; set; }
 		public long monthlyPayAsYouGo { get; set; }
-		public Dictionary<DateTime, long> dailyUsage { get; set; }
-		public Dictionary<string, long> tokenUsage { get; set; }
-		public UsageResponseKeyUsage keyUsage { get; set; }
-	}
-
-	public class UsageResponseKeyUsage
-	{
-		public long IEX_TOPS { get; set; }
-		public int COMPANY { get; set; }
-		public long IEX_STATS { get; set; }
-		public long EARNINGS { get; set; }
-		public long STOCK_QUOTES { get; set; }
+		public Dictionary<DateTime, string> dailyUsage { get; set; }
+		public Dictionary<string, string> tokenUsage { get; set; }
+		public Dictionary<string, string> keyUsage { get; set; }
 	}
 }

--- a/IEXSharp/Service/Cloud/Account/AccountService.cs
+++ b/IEXSharp/Service/Cloud/Account/AccountService.cs
@@ -44,6 +44,17 @@ namespace IEXSharp.Service.Cloud.Account
 			return await executor.ExecuteAsync<UsageResponse>(urlPattern, pathNVC, qsb, forceUseSecretToken: true);
 		}
 
+		public async Task<IEXResponse<MessageUsageResponse>> MessageUsageAsync()
+		{
+			var urlPattern = $"account/usage/messages";
+
+			var qsb = new QueryStringBuilder();
+
+			var pathNVC = new NameValueCollection();
+
+			return await executor.ExecuteAsync<MessageUsageResponse>(urlPattern, pathNVC, qsb, forceUseSecretToken: true);
+		}
+
 		public Task PayAsYouGoAsync(bool allow)
 		{
 			throw new NotImplementedException("Not implemented due to API failed");

--- a/IEXSharp/Service/Cloud/Account/IAccountService.cs
+++ b/IEXSharp/Service/Cloud/Account/IAccountService.cs
@@ -2,6 +2,7 @@ using IEXSharp.Model;
 using System.Threading.Tasks;
 using IEXSharp.Model.Account.Request;
 using IEXSharp.Model.Account.Response;
+using System.Collections.Generic;
 
 namespace IEXSharp.Service.Cloud.Account
 {
@@ -18,6 +19,12 @@ namespace IEXSharp.Service.Cloud.Account
 		/// </summary>
 		/// <returns></returns>
 		Task<IEXResponse<UsageResponse>> UsageAsync(UsageType type);
+
+		/// <summary>
+		/// <see cref="https://iexcloud.io/docs/api/#usage"/>
+		/// </summary>
+		/// <returns></returns>
+		Task<IEXResponse<MessageUsageResponse>> MessageUsageAsync();
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#pay-as-you-go"/>

--- a/IEXSharp/Service/Legacy/Stock/IStockService.cs
+++ b/IEXSharp/Service/Legacy/Stock/IStockService.cs
@@ -6,8 +6,6 @@ using IEXSharp.Model.CoreData.Batch.Response;
 using IEXSharp.Model.CoreData.MarketInfo.Request;
 using IEXSharp.Model.CoreData.MarketInfo.Response;
 using IEXSharp.Model.CoreData.Stock.Response;
-using IEXSharp.Model.CoreData.StockFundamentals.Request;
-using IEXSharp.Model.CoreData.StockFundamentals.Response;
 using IEXSharp.Model.CoreData.StockPrices.Response;
 using IEXSharp.Model.CoreData.StockProfiles.Response;
 

--- a/IEXSharp/Service/Legacy/Stock/StockService.cs
+++ b/IEXSharp/Service/Legacy/Stock/StockService.cs
@@ -10,8 +10,6 @@ using IEXSharp.Model.CoreData.Batch.Response;
 using IEXSharp.Model.CoreData.MarketInfo.Request;
 using IEXSharp.Model.CoreData.MarketInfo.Response;
 using IEXSharp.Model.CoreData.Stock.Response;
-using IEXSharp.Model.CoreData.StockFundamentals.Request;
-using IEXSharp.Model.CoreData.StockFundamentals.Response;
 using IEXSharp.Model.CoreData.StockPrices.Response;
 using IEXSharp.Model.CoreData.StockProfiles.Response;
 

--- a/IEXSharpTest/Cloud/AccountTest.cs
+++ b/IEXSharpTest/Cloud/AccountTest.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using IEXSharp;
 using IEXSharp.Model.Account.Request;
+using IEXSharp.Model.Account.Response;
 
 namespace IEXSharpTest.Cloud
 {
@@ -26,13 +28,46 @@ namespace IEXSharpTest.Cloud
 
 		[Test]
 		[TestCase(UsageType.All)]
-		[TestCase(UsageType.Messages)]
 		public async Task UsageAsyncTest(UsageType type)
 		{
 			var response = await sandBoxClient.Account.UsageAsync(type);
 
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
+
+			UsageResponse usageResponse = response.Data;
+			UsageResponseMessages messages = usageResponse.messages;
+
+			Assert.Greater(messages.monthlyUsage, 0);
+			Assert.Greater(int.Parse(messages.keyUsage.GetValueOrDefault("FX_CONVERSION")), 0);
+		}
+
+		[Test]
+		public async Task MessageUsageAsyncTest()
+		{
+			var response = await sandBoxClient.Account.MessageUsageAsync();
+
+			Assert.IsNull(response.ErrorMessage);
+			Assert.IsNotNull(response.Data);
+
+			MessageUsageResponse usageResponse = response.Data;
+
+			Assert.Greater(usageResponse.monthlyUsage, 0);
+			Assert.Greater(int.Parse(usageResponse.keyUsage.GetValueOrDefault("FX_CONVERSION")), 0);
+		}
+
+		[Test]
+		// TODO - Rules appears to have a different response from these, returns an empty array.
+		[TestCase(UsageType.Rules)]
+		[TestCase(UsageType.RuleRecords)]
+		[TestCase(UsageType.Alerts)]
+		[TestCase(UsageType.AlertRecords)]
+		public async Task UnauthorisedUsageAsyncTest(UsageType type)
+		{
+			var response = await sandBoxClient.Account.UsageAsync(type);
+
+			// This is due to a key on the Start plan and lack of documentation on https://iexcloud.io/docs/api/#usage around these.
+			Assert.AreEqual("Forbidden - The API key provided is not valid.", response.ErrorMessage);
 		}
 	}
 }

--- a/IEXSharpTest/IEXSharpTest.csproj
+++ b/IEXSharpTest/IEXSharpTest.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IEXSharpTest/Legacy/StockTest.cs
+++ b/IEXSharpTest/Legacy/StockTest.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using IEXSharp;
 using IEXSharp.Model.CoreData.Batch.Request;
 using IEXSharp.Model.CoreData.MarketInfo.Request;
-using IEXSharp.Model.CoreData.StockFundamentals.Request;
 
 namespace IEXSharpTest.Legacy
 {


### PR DESCRIPTION
Noticed this when I started looking into nullable properties.

- Added different response model for Message Usage Async. (I cannot see examples of the other responses and am only getting "Forbidden - The API key provided is not valid."
- Fixed incorrect descriptions in usage types, these were giving 404s.
- Cleanup usings.
- Bumped NUnit3TestAdapter & Microsoft.NET.Test.Sdk Package versions.