### PR TITLE
Added a new JSON converter to handle nullable DateTime values

### DIFF
--- a/IEXSharp/Helper/ExecutorBase.cs
+++ b/IEXSharp/Helper/ExecutorBase.cs
@@ -21,7 +21,9 @@ namespace IEXSharp.Helper
 			get
 			{
 				if (jsonSerializerOptions != null)
+				{
 					return jsonSerializerOptions;
+				}
 				else
 				{
 					jsonSerializerOptions = new JsonSerializerOptions
@@ -34,6 +36,7 @@ namespace IEXSharp.Helper
 					jsonSerializerOptions.Converters.Add(new Int64Converter());
 					jsonSerializerOptions.Converters.Add(new DecimalConverter());
 					jsonSerializerOptions.Converters.Add(new StringConverter());
+					jsonSerializerOptions.Converters.Add(new DateTimeConverter());
 					return jsonSerializerOptions;
 				}
 			}

--- a/IEXSharp/Helper/JSONConverters.cs
+++ b/IEXSharp/Helper/JSONConverters.cs
@@ -13,20 +13,36 @@ namespace IEXSharp.Helper
 			JsonSerializerOptions options)
 		{
 			if (reader.TokenType == JsonTokenType.String)
+			{
 				return reader.GetString();
+			}
 			else if (reader.TokenType == JsonTokenType.True)
+			{
 				return "true";
+			}
 			else if (reader.TokenType == JsonTokenType.False)
+			{
 				return "false";
+			}
 			else if (reader.TokenType == JsonTokenType.Number)
 			{
 				if (reader.TryGetInt64(out long l))
+				{
 					return l.ToString();
-				else return reader.GetDecimal().ToString();
+				}
+				else
+				{
+					return reader.GetDecimal().ToString();
+				}
 			}
 			else if (reader.TokenType == JsonTokenType.Null)
+			{
 				return null;
-			else throw new JsonException();
+			}
+			else
+			{
+				throw new JsonException();
+			}
 		}
 
 		public override void Write(Utf8JsonWriter writer, string value,
@@ -42,14 +58,15 @@ namespace IEXSharp.Helper
 			{
 				var stringValue = reader.GetString();
 				if (int.TryParse(stringValue, out var value))
+				{
 					return value;
-
+				}
 				return null;
 			}
-
 			if (reader.TokenType == JsonTokenType.Number)
+			{
 				return reader.GetInt32();
-
+			}
 			throw new JsonException();
 		}
 
@@ -59,6 +76,37 @@ namespace IEXSharp.Helper
 			if (input.HasValue)
 			{
 				writer.WriteNumberValue(input.Value);
+			}
+			else
+			{
+				writer.WriteNullValue();
+			}
+		}
+	}
+
+	public class DateTimeConverter : JsonConverter<DateTime?>
+	{
+		public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String &&
+				typeToConvert == typeof(DateTime?))
+			{
+				var stringValue = reader.GetString();
+				if (DateTime.TryParse(stringValue, out var value))
+				{
+					return value;
+				}
+				return null;
+			}
+			throw new JsonException();
+		}
+
+		public override void Write(Utf8JsonWriter writer, DateTime? input,
+			JsonSerializerOptions options)
+		{
+			if (input.HasValue)
+			{
+				writer.WriteStringValue(input.Value);
 			}
 			else
 			{
@@ -79,13 +127,12 @@ namespace IEXSharp.Helper
 				{
 					return value;
 				}
-
 				return null;
 			}
-
 			if (reader.TokenType == JsonTokenType.Number)
+			{
 				return reader.GetInt64();
-
+			}
 			throw new JsonException();
 		}
 
@@ -115,13 +162,12 @@ namespace IEXSharp.Helper
 				{
 					return value;
 				}
-
 				return null;
 			}
-
 			if (reader.TokenType == JsonTokenType.Number)
+			{
 				return reader.GetDecimal();
-
+			}
 			throw new JsonException();
 		}
 

--- a/IEXSharpTest/Cloud/CoreData/StockResearchTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockResearchTest.cs
@@ -19,6 +19,7 @@ namespace IEXSharpTest.Cloud.CoreData
 		[Test]
 		[TestCase("AACG")]
 		[TestCase("AACQ")]
+		[TestCase("AACQU")]
 		[TestCase("AAPL")]
 		[TestCase("FB")]
 		public async Task AdvancedStatsAsyncTest(string symbol)
@@ -28,8 +29,10 @@ namespace IEXSharpTest.Cloud.CoreData
 			Assert.IsNull(response.ErrorMessage);
 			Assert.IsNotNull(response.Data);
 
-			Assert.NotNull(response.Data.marketcap);
-			Assert.NotNull(response.Data.beta);
+			// Removing these, as AACQU brings back everything as null, except for the company name
+			//Assert.NotNull(response.Data.marketcap);
+			//Assert.NotNull(response.Data.beta);
+			Assert.NotNull(response.Data.companyName);
 		}
 
 		[Test]
@@ -101,6 +104,7 @@ namespace IEXSharpTest.Cloud.CoreData
 		[Test]
 		[TestCase("AACG")]
 		[TestCase("AACQ")]
+		[TestCase("AACQU")]
 		[TestCase("AAPL")]
 		[TestCase("FB")]
 		public async Task KeyStatsAsyncTest(string symbol)


### PR DESCRIPTION
This was to handle the case for AACQU, which brought all values back as null, except for the company name.