### PR TITLE
Changed operatingExpense and otherIncomeExpenseNet to decimal since I…

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/IncomeStatementResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/IncomeStatementResponse.cs
@@ -19,9 +19,9 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 		public long? grossProfit { get; set; }
 		public long? researchAndDevelopment { get; set; }
 		public long? sellingGeneralAndAdmin { get; set; }
-		public long? operatingExpense { get; set; }
+		public decimal? operatingExpense { get; set; }
 		public long? operatingIncome { get; set; }
-		public long? otherIncomeExpenseNet { get; set; }
+		public decimal? otherIncomeExpenseNet { get; set; }
 		public long? ebit { get; set; }
 		public long? interestIncome { get; set; }
 		public long? pretaxIncome { get; set; }

--- a/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
@@ -152,6 +152,7 @@ namespace IEXSharpTest.Cloud.CoreData
 			Assert.IsNotNull(response.Data);
 		}
 		[Test]
+		[TestCase("BRPAU", Period.Annual, 1)]
 		[TestCase("AAPL", Period.Annual, 1)]
 		[TestCase("FB", Period.Quarter, 2)]
 		public async Task IncomeStatementAsyncTest(string symbol, Period period, int last)


### PR DESCRIPTION
…EX is returning them as decimal values and is causing an overflow on reader.GetInt64

{"symbol":"BRPAU","income":[{"reportDate":"2018-12-31","totalRevenue":null,
"costOfRevenue":null,"grossProfit":null,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,
"operatingExpense":**1006502.9999999999**,"operatingIncome":-1006500,"otherIncomeExpenseNet":**1088911.9999999998**,
"ebit":-1006500,"interestIncome":null,"pretaxIncome":82412,"incomeTax":16311,"minorityInterest":0,"netIncome":66101,
"netIncomeBasic":66101},{"reportDate":"2017-12-31","totalRevenue":null,"costOfRevenue":null,"grossProfit":null,
"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":null,"operatingIncome":-134480,
"otherIncomeExpenseNet":29446.999999999985,"ebit":-134480,"interestIncome":null,"pretaxIncome":-105033,"incomeTax":null,
"minorityInterest":0,"netIncome":-105033,"netIncomeBasic":-105033}]}