### PR TITLE
Changed all nullable long properties in IncomeStatementResponse to nu…

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/IncomeStatementResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/IncomeStatementResponse.cs
@@ -14,20 +14,20 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 		public DateTime reportDate { get; set; }
 		public DateTime fiscalDate { get; set; }
 		public string currency { get; set; }
-		public long? totalRevenue { get; set; }
-		public long? costOfRevenue { get; set; }
-		public long? grossProfit { get; set; }
-		public long? researchAndDevelopment { get; set; }
-		public long? sellingGeneralAndAdmin { get; set; }
+		public decimal? totalRevenue { get; set; }
+		public decimal? costOfRevenue { get; set; }
+		public decimal? grossProfit { get; set; }
+		public decimal? researchAndDevelopment { get; set; }
+		public decimal? sellingGeneralAndAdmin { get; set; }
 		public decimal? operatingExpense { get; set; }
-		public long? operatingIncome { get; set; }
+		public decimal? operatingIncome { get; set; }
 		public decimal? otherIncomeExpenseNet { get; set; }
-		public long? ebit { get; set; }
-		public long? interestIncome { get; set; }
-		public long? pretaxIncome { get; set; }
-		public long? incomeTax { get; set; }
-		public long? minorityInterest { get; set; }
-		public long? netIncome { get; set; }
-		public long? netIncomeBasic { get; set; }
+		public decimal? ebit { get; set; }
+		public decimal? interestIncome { get; set; }
+		public decimal? pretaxIncome { get; set; }
+		public decimal? incomeTax { get; set; }
+		public decimal? minorityInterest { get; set; }
+		public decimal? netIncome { get; set; }
+		public decimal? netIncomeBasic { get; set; }
 	}
 }

--- a/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
@@ -153,6 +153,7 @@ namespace IEXSharpTest.Cloud.CoreData
 		}
 		[Test]
 		[TestCase("BRPAU", Period.Annual, 1)]
+		[TestCase("BRPAU", Period.Quarter, 1)]
 		[TestCase("AAPL", Period.Annual, 1)]
 		[TestCase("FB", Period.Quarter, 2)]
 		public async Task IncomeStatementAsyncTest(string symbol, Period period, int last)


### PR DESCRIPTION
…llable decimal to avoid JSON overflow errors.

Another Int64 overflow error:

Error loading the quarterly financial statement data for BRPAU.
[10/14/2020 03:31:54 > b0c34e: INFO] System.Text.Json.JsonException: {"symbol":"BRPAU","income":[{"reportDate":"2019-03-31","totalRevenue":null,"costOfRevenue":null,"grossProfit":null,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":163181,"operatingIncome":-163180,"otherIncomeExpenseNet":382861,"ebit":-163180,"interestIncome":null,"pretaxIncome":219681,"incomeTax":31716,"minorityInterest":0,"netIncome":187965,"netIncomeBasic":187965},{"reportDate":"2018-12-31","totalRevenue":null,"costOfRevenue":null,"grossProfit":null,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":322076,"operatingIncome":-322080,"otherIncomeExpenseNet":319478,"ebit":-322080,"interestIncome":null,"pretaxIncome":-2602,"incomeTax":-31741,"minorityInterest":0,"netIncome":29139,"netIncomeBasic":29139},{"reportDate":"2018-09-30","totalRevenue":null,"costOfRevenue":null,"grossProfit":null,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":220243,"operatingIncome":-220240,"otherIncomeExpenseNet":283313,"ebit":-220240,"interestIncome":null,"pretaxIncome":63073.00000000001,"incomeTax":34989,"minorityInterest":0,"netIncome":28084,"netIncomeBasic":28084},{"reportDate":"2018-06-30","totalRevenue":null,"costOfRevenue":null,"grossProfit":null,"researchAndDevelopment":null,"sellingGeneralAndAdmin":271810,"operatingExpense":271810,"operatingIncome":-271810,"otherIncomeExpenseNet":274156,"ebit":-271810,"interestIncome":null,"pretaxIncome":2346,"incomeTax":8948,"minorityInterest":0,"netIncome":-6602,"netIncomeBasic":-6602}]}
[10/14/2020 03:31:54 > b0c34e: INFO]  ---> System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[System.Int64]. Path: $.income[2].pretaxIncome | LineNumber: 0 | BytePositionInLine: 1069.
[10/14/2020 03:31:54 > b0c34e: INFO]  ---> System.FormatException: Either the JSON value is not in a supported format, or is out of bounds for an Int64.