### PR TITLE
Changed all balance sheet properties from nullable long to nullable d…

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/BalanceSheetResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/BalanceSheetResponse.cs
@@ -14,31 +14,31 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 		public DateTime reportDate { get; set; }
 		public DateTime fiscalDate { get; set; }
 		public string currency { get; set; }
-		public long? currentCash { get; set; }
-		public long? shortTermInvestments { get; set; }
-		public long? receivables { get; set; }
-		public long? inventory { get; set; }
-		public long? otherCurrentAssets { get; set; }
-		public long? currentAssets { get; set; }
-		public long? longTermInvestments { get; set; }
-		public long? propertyPlantEquipment { get; set; }
-		public long? goodwill { get; set; }
-		public long? intangibleAssets { get; set; }
-		public long? otherAssets { get; set; }
-		public long? totalAssets { get; set; }
-		public long? accountsPayable { get; set; }
-		public long? currentLongTermDebt { get; set; }
-		public long? otherCurrentLiabilities { get; set; }
-		public long? totalCurrentLiabilities { get; set; }
-		public long? longTermDebt { get; set; }
-		public long? otherLiabilities { get; set; }
-		public long? minorityInterest { get; set; }
-		public long? totalLiabilities { get; set; }
-		public long? commonStock { get; set; }
-		public long? retainedEarnings { get; set; }
-		public long? treasuryStock { get; set; }
-		public long? capitalSurplus { get; set; }
-		public long? shareholderEquity { get; set; }
-		public long? netTangibleAssets { get; set; }
+		public decimal? currentCash { get; set; }
+		public decimal? shortTermInvestments { get; set; }
+		public decimal? receivables { get; set; }
+		public decimal? inventory { get; set; }
+		public decimal? otherCurrentAssets { get; set; }
+		public decimal? currentAssets { get; set; }
+		public decimal? longTermInvestments { get; set; }
+		public decimal? propertyPlantEquipment { get; set; }
+		public decimal? goodwill { get; set; }
+		public decimal? intangibleAssets { get; set; }
+		public decimal? otherAssets { get; set; }
+		public decimal? totalAssets { get; set; }
+		public decimal? accountsPayable { get; set; }
+		public decimal? currentLongTermDebt { get; set; }
+		public decimal? otherCurrentLiabilities { get; set; }
+		public decimal? totalCurrentLiabilities { get; set; }
+		public decimal? longTermDebt { get; set; }
+		public decimal? otherLiabilities { get; set; }
+		public decimal? minorityInterest { get; set; }
+		public decimal? totalLiabilities { get; set; }
+		public decimal? commonStock { get; set; }
+		public decimal? retainedEarnings { get; set; }
+		public decimal? treasuryStock { get; set; }
+		public decimal? capitalSurplus { get; set; }
+		public decimal? shareholderEquity { get; set; }
+		public decimal? netTangibleAssets { get; set; }
 	}
 }

--- a/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
@@ -24,6 +24,7 @@ namespace IEXSharpTest.Cloud.CoreData
 		}
 
 		[Test]
+		[TestCase("CCM", Period.Quarter, 1)]
 		[TestCase("AAPL", Period.Quarter, 1)]
 		[TestCase("FB", Period.Quarter, 2)]
 		public async Task BalanceSheetAsyncTest(string symbol, Period period = Period.Quarter,


### PR DESCRIPTION
…ecimal to avoid overflow errors

Fix for the following error:

System.Text.Json.JsonException: {"symbol":"CCM","balancesheet":[{"reportDate":"2016-06-30","currentCash":153060627.07999998,"shortTermInvestments":null,"receivables":46325991.96,"inventory":700369.5599999999,"otherCurrentAssets":11706090.92,"currentAssets":211793079.51999998,"longTermInvestments":34669723.16,"propertyPlantEquipment":145565182.64,"goodwill":0,"intangibleAssets":5577970.159999999,"otherAssets":101926880,"totalAssets":513770969.64,"accountsPayable":476245.27999999997,"currentLongTermDebt":39487416.8,"otherCurrentLiabilities":50982930.24,"totalCurrentLiabilities":216830381.84,"longTermDebt":77950243.96,"otherLiabilities":443280,"minorityInterest":-70012,"totalLiabilities":303941574.03999996,"commonStock":null,"retainedEarnings":-58204277.76,"treasuryStock":1204.1599999999999,"capitalSurplus":263268360.68,"shareholderEquity":197342707.96,"netTangibleAssets":197342707.96}]} ---> System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[System.Int64]. Path: $.balancesheet[0].currentCash | 