### PR TITLE
Made reportDate and fiscalDate nullable for income statement and bala…

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/BalanceSheetResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/BalanceSheetResponse.cs
@@ -11,8 +11,8 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 
 	public class Balancesheet
 	{
-		public DateTime reportDate { get; set; }
-		public DateTime fiscalDate { get; set; }
+		public DateTime? reportDate { get; set; }
+		public DateTime? fiscalDate { get; set; }
 		public string currency { get; set; }
 		public decimal? currentCash { get; set; }
 		public decimal? shortTermInvestments { get; set; }

--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/IncomeStatementResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/IncomeStatementResponse.cs
@@ -11,8 +11,8 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 
 	public class Income
 	{
-		public DateTime reportDate { get; set; }
-		public DateTime fiscalDate { get; set; }
+		public DateTime? reportDate { get; set; }
+		public DateTime? fiscalDate { get; set; }
 		public string currency { get; set; }
 		public decimal? totalRevenue { get; set; }
 		public decimal? costOfRevenue { get; set; }

--- a/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
@@ -24,6 +24,8 @@ namespace IEXSharpTest.Cloud.CoreData
 		}
 
 		[Test]
+		[TestCase("BEDU", Period.Annual, 1)]
+		[TestCase("BEDU", Period.Quarter, 1)]
 		[TestCase("CCM", Period.Quarter, 1)]
 		[TestCase("AAPL", Period.Quarter, 1)]
 		[TestCase("FB", Period.Quarter, 2)]
@@ -153,6 +155,8 @@ namespace IEXSharpTest.Cloud.CoreData
 			Assert.IsNotNull(response.Data);
 		}
 		[Test]
+		[TestCase("BEDU", Period.Annual, 1)]
+		[TestCase("BEDU", Period.Quarter, 1)]
 		[TestCase("BRPAU", Period.Annual, 1)]
 		[TestCase("BRPAU", Period.Quarter, 1)]
 		[TestCase("AAPL", Period.Annual, 1)]
@@ -177,8 +181,8 @@ namespace IEXSharpTest.Cloud.CoreData
 
 			var response = await sandBoxClient.StockFundamentals.IncomeStatementAsync(symbol, period, upToXStatements);
 
-			var firstStatementReportYear = response.Data.income.ElementAt(0).reportDate.Year;
-			var secondStatementReportYear = response.Data.income.ElementAt(1).reportDate.Year;
+			var firstStatementReportYear = response.Data.income.ElementAt(0).reportDate?.Year;
+			var secondStatementReportYear = response.Data.income.ElementAt(1).reportDate?.Year;
 
 			Assert.That(firstStatementReportYear != secondStatementReportYear);
 		}


### PR DESCRIPTION
…nce sheet

Fixes the following error:

System.Text.Json.JsonException: {"symbol":"BEDU","income":[{"reportDate":"2020-05-31","fiscalDate":"2020-05-31","currency":"USD","totalRevenue":104640694,"costOfRevenue":63321213,"grossProfit":41319481,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":86857055,"operatingIncome":17783640,"otherIncomeExpenseNet":-3135726,"ebit":17783640,"interestIncome":6097660,"pretaxIncome":14647914,"incomeTax":5020812,"minorityInterest":-1244129,"netIncome":10868542,"netIncomeBasic":10868542},{"reportDate":"2020-02-29","fiscalDate":"2020-02-29","currency":"USD","totalRevenue":125697738,"costOfRevenue":81763201,"grossProfit":43934537,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":115056925,"operatingIncome":10640810,"otherIncomeExpenseNet":-2131887,"ebit":10640810,"interestIncome":4819860,"pretaxIncome":8508923,"incomeTax":2676649,"minorityInterest":-898905,"netIncome":6701655,"netIncomeBasic":6701655},{"reportDate":"2019-11-30","fiscalDate":null,"currency":"USD","totalRevenue":155371329,"costOfRevenue":88330825,"grossProfit":67040504,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":118038019,"operatingIncome":37333310,"otherIncomeExpenseNet":-211558,"ebit":37333310,"interestIncome":4186998,"pretaxIncome":37121752,"incomeTax":8209703,"minorityInterest":1839347,"netIncome":27068882,"netIncomeBasic":27068882},{"reportDate":"2019-08-31","fiscalDate":"2019-08-31","currency":"USD","totalRevenue":102413679,"costOfRevenue":71885462,"grossProfit":30528217,"researchAndDevelopment":null,"sellingGeneralAndAdmin":null,"operatingExpense":109301516,"operatingIncome":-6887840,"otherIncomeExpenseNet":-826721,"ebit":-6887840,"interestIncome":1156608,"pretaxIncome":-7714561,"incomeTax":-819816,"minorityInterest":546640,"netIncome":-7473337,"netIncomeBasic":-7473337}]}
[10/15/2020 01:16:31 > b0c34e: INFO]  ---> System.Text.Json.JsonException: The JSON value could not be converted to System.DateTime. Path: $.income[2].fiscalDate | LineNumber: 0 | BytePositionInLine: 972.
[10/15/2020 01:16:31 > b0c34e: INFO]  ---> System.InvalidOperationException: Cannot get the value of a token type 'Null' as a string.
[10/15/2020 01:16:31 > b0c34e: INFO]    at System.Text.Json.Utf8JsonReader.TryGetDateTime(DateTime& value)