### PR TITLE
Change employees to nullable int to match data

### DIFF
--- a/IEXSharp/Model/CoreData/StockProfiles/Response/CompanyResponse.cs
+++ b/IEXSharp/Model/CoreData/StockProfiles/Response/CompanyResponse.cs
@@ -14,7 +14,7 @@ namespace IEXSharp.Model.CoreData.StockProfiles.Response
 		public string issueType { get; set; }
 		public string sector { get; set; }
 		public string primarySicCode { get; set; }
-		public int employees { get; set; }
+		public int? employees { get; set; }
 		public List<string> tags { get; set; }
 		public string address { get; set; }
 		public string address2 { get; set; }


### PR DESCRIPTION
Change employees to nullable so matches response and passes test.

```
{
    "symbol": "ACRE",
    "securityName": "Ares Commercial Real Estate Corp",
    "employees": null,
     ...
}
```