### PR TITLE
Advanced fundamentals fixes cum upgrades

### DIFF
--- a/IEXSharp/Helper/DateTimeExtensions.cs
+++ b/IEXSharp/Helper/DateTimeExtensions.cs
@@ -25,6 +25,13 @@ namespace IEXSharp.Helper
 		/// <param name="unixTime"></param>
 		/// <returns></returns>
 		public static DateTime ConvertFromUnixMilliSecToDateTime(this long unixTime) => UnixEpoch.AddMilliseconds(unixTime);
+
+		/// <summary>
+		/// Converts DateTime object to time series endpoint compatible query param value
+		/// </summary>
+		/// <param name="date"></param>
+		/// <returns></returns>
+		public static string ToTimeSeriesDate(this DateTime date) => date.ToString("yyyy-MM-dd");
 	}
 
 	public interface ITimestampedDateMinute

--- a/IEXSharp/IEXSharp.csproj
+++ b/IEXSharp/IEXSharp.csproj
@@ -22,7 +22,6 @@
 		<Product>VSLee.IEXSharp</Product>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<Copyright>2019 Victor Lee</Copyright>
-		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<!--when prereleasing, embed symbols PDB in main nupkg bc GH Pakages doesn't have its own symbol server-->

--- a/IEXSharp/IEXSharp.csproj
+++ b/IEXSharp/IEXSharp.csproj
@@ -22,6 +22,7 @@
 		<Product>VSLee.IEXSharp</Product>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<Copyright>2019 Victor Lee</Copyright>
+		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<!--when prereleasing, embed symbols PDB in main nupkg bc GH Pakages doesn't have its own symbol server-->
@@ -38,8 +39,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Folder Include="Model\CoreData" />
-		<Folder Include="Model\Shared\Request\" />
 		<Folder Include="Service\Cloud\CoreData" />
 	</ItemGroup>
 

--- a/IEXSharp/Model/Shared/Request/TimeSeries.cs
+++ b/IEXSharp/Model/Shared/Request/TimeSeries.cs
@@ -13,8 +13,7 @@ namespace IEXSharp.Model.Shared.Request
 			this.period = period;
 		}
 
-		private int _Range { get; set; }
-		private string Range => period == TimeSeriesPeriod.Quarterly ? _Range + "q" : _Range + "y";
+		private string Range { get; set; }
 		private bool Calendar { get; set; }
 		private int Limit { get; set; }
 		private string From { get; set; }
@@ -22,13 +21,14 @@ namespace IEXSharp.Model.Shared.Request
 		private int Last { get; set; }
 		private int First { get; set; }
 
-		public TimeSeries AddRange(int range)
+		public TimeSeries SetRange(int range)
 		{
-			_Range = range;
+			if (range <= 0) return this;
+			Range = period == TimeSeriesPeriod.Quarterly ? range + "q" : range + "y";
 			return this;
 		}
 
-		public TimeSeries AddDateRange(DateTime? from, DateTime? to = default)
+		public TimeSeries SetDateRange(DateTime? from, DateTime? to = default)
 		{
 			if (from == null) return this;
 			From = from?.ToTimeSeriesDate();
@@ -46,7 +46,7 @@ namespace IEXSharp.Model.Shared.Request
 				nvc.Add("to", To);
 			}
 
-			if (_Range > 0 && string.IsNullOrEmpty(From))
+			if (!string.IsNullOrEmpty(Range) && string.IsNullOrEmpty(From))
 			{
 				nvc.Add("range", Range);
 			}

--- a/IEXSharp/Model/Shared/Request/TimeSeries.cs
+++ b/IEXSharp/Model/Shared/Request/TimeSeries.cs
@@ -1,0 +1,57 @@
+using System;
+using Common.Logging.Configuration;
+using IEXSharp.Helper;
+
+namespace IEXSharp.Model.Shared.Request
+{
+	public class TimeSeries
+	{
+		private readonly TimeSeriesPeriod period;
+
+		public TimeSeries(TimeSeriesPeriod period)
+		{
+			this.period = period;
+		}
+
+		private int _Range { get; set; }
+		private string Range => period == TimeSeriesPeriod.Quarterly ? _Range + "q" : _Range + "y";
+		private bool Calendar { get; set; }
+		private int Limit { get; set; }
+		private string From { get; set; }
+		private string To { get; set; }
+		private int Last { get; set; }
+		private int First { get; set; }
+
+		public TimeSeries AddRange(int range)
+		{
+			_Range = range;
+			return this;
+		}
+
+		public TimeSeries AddDateRange(DateTime? from, DateTime? to = default)
+		{
+			if (from == null) return this;
+			From = from?.ToTimeSeriesDate();
+			To = to?.ToTimeSeriesDate() ?? DateTime.Today.ToTimeSeriesDate();
+			return this;
+		}
+
+		public NameValueCollection TimeSeriesQueryParams()
+		{
+			var nvc = new NameValueCollection();
+
+			if (From != null)
+			{
+				nvc.Add("from", From);
+				nvc.Add("to", To);
+			}
+
+			if (_Range > 0 && string.IsNullOrEmpty(From))
+			{
+				nvc.Add("range", Range);
+			}
+
+			return nvc;
+		}
+	}
+}

--- a/IEXSharp/Model/Shared/Request/TimeSeriesPeriod.cs
+++ b/IEXSharp/Model/Shared/Request/TimeSeriesPeriod.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+
+namespace IEXSharp.Model.Shared.Request
+{
+	public enum TimeSeriesPeriod
+	{
+		[Description("quarterly")]
+		Quarterly,
+		[Description("annual")]
+		Annual,
+		[Description("ttm")]
+		Ttm
+	}
+}

--- a/IEXSharp/Model/Shared/Request/TimeSeriesRange.cs
+++ b/IEXSharp/Model/Shared/Request/TimeSeriesRange.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+
+namespace IEXSharp.Model.Shared.Request
+{
+	public enum TimeSeriesRange
+	{
+		[Description("today")]
+		Today,
+		[Description("yesterday")]
+		Yesterday,
+		[Description("ytd")]
+		Ytd,
+		[Description("last-week")]
+		LastWeek,
+		[Description("last-month")]
+		LastMonth,
+		[Description("last-quarter")]
+		LastQuarter,
+		[Description("d")]
+		Days,
+		[Description("w")]
+		Weeks,
+		[Description("m")]
+		Months,
+		[Description("q")]
+		Quarters,
+		[Description("y")]
+		Years,
+		[Description("tomorrow")]
+		Tomorrow,
+		[Description("this-week")]
+		ThisWeek,
+		[Description("this-month")]
+		ThisMonth,
+		[Description("this-quarter")]
+		ThisQuarter,
+		[Description("next-week")]
+		NextWeek,
+		[Description("next-month")]
+		NextMonth,
+		[Description("next-quarter")]
+		NextQuarter
+	}
+}

--- a/IEXSharp/Service/Cloud/CoreData/StockFundamentals/IStockFundamentalsService.cs
+++ b/IEXSharp/Service/Cloud/CoreData/StockFundamentals/IStockFundamentalsService.cs
@@ -16,8 +16,9 @@ namespace IEXSharp.Service.Cloud.CoreData.StockFundamentals
 		/// </summary>
 		/// <param name="symbol"></param>
 		/// <param name="period"></param>
+		/// <param name="timeSeries"></param>
 		/// <returns></returns>
-		Task<IEXResponse<IEnumerable<AdvancedFundamentalsResponse>>> AdvancedFundamentalsAsync(string symbol, Period period = Period.Quarter);
+		Task<IEXResponse<IEnumerable<AdvancedFundamentalsResponse>>> AdvancedFundamentalsAsync(string symbol, TimeSeriesPeriod period = TimeSeriesPeriod.Quarterly, TimeSeries timeSeries = null);
 
 		/// <summary>
 		/// <see cref="https://iexcloud.io/docs/api/#balance-sheet"/>

--- a/IEXSharp/Service/Cloud/CoreData/StockFundamentals/StockFundamentalsService.cs
+++ b/IEXSharp/Service/Cloud/CoreData/StockFundamentals/StockFundamentalsService.cs
@@ -18,11 +18,20 @@ namespace IEXSharp.Service.Cloud.CoreData.StockFundamentals
 			this.executor = executor;
 		}
 
-		public async Task<IEXResponse<IEnumerable<AdvancedFundamentalsResponse>>> AdvancedFundamentalsAsync(string symbol, Period period = Period.Quarter)
+		public async Task<IEXResponse<IEnumerable<AdvancedFundamentalsResponse>>> AdvancedFundamentalsAsync(string symbol, TimeSeriesPeriod period = TimeSeriesPeriod.Quarterly, TimeSeries timeSeries = null)
 		{
 			const string urlPattern = "time-series/fundamentals/[symbol]/[period]";
 
 			var qsb = new QueryStringBuilder();
+
+			if (timeSeries != null)
+			{
+				var queryParams = timeSeries.TimeSeriesQueryParams();
+				foreach (var nameValue in queryParams)
+				{
+					qsb.Add(nameValue.Key, nameValue.Value);
+				}
+			}
 
 			var pathNvc = new NameValueCollection
 			{
@@ -33,8 +42,7 @@ namespace IEXSharp.Service.Cloud.CoreData.StockFundamentals
 			return await executor.ExecuteAsync<IEnumerable<AdvancedFundamentalsResponse>>(urlPattern, pathNvc, qsb);
 		}
 
-		public async Task<IEXResponse<BalanceSheetResponse>> BalanceSheetAsync(string symbol, Period period = Period.Quarter,
-			int last = 1)
+		public async Task<IEXResponse<BalanceSheetResponse>> BalanceSheetAsync(string symbol, Period period = Period.Quarter, int last = 1)
 		{
 			const string urlPattern = "stock/[symbol]/balance-sheet/[last]";
 

--- a/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
@@ -40,7 +40,7 @@ namespace IEXSharpTest.Cloud.CoreData
 		[TestCase("AAPL", TimeSeriesPeriod.Quarterly, null, "2008-1-1", "2010-1-1")]
 		public async Task AdvancedFundamentalsAsyncTest(string symbol, TimeSeriesPeriod period = TimeSeriesPeriod.Quarterly, int range = 1, DateTime? from = null, DateTime? to = null)
 		{
-			var timeSeries = new TimeSeries(period).AddRange(range).AddDateRange(from, to);
+			var timeSeries = new TimeSeries(period).SetRange(range).SetDateRange(from, to);
 			var response = await sandBoxClient.StockFundamentals.AdvancedFundamentalsAsync(symbol, period, timeSeries);
 
 			Assert.IsNull(response.ErrorMessage);

--- a/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
+++ b/IEXSharpTest/Cloud/CoreData/StockFundamentalsTest.cs
@@ -24,15 +24,24 @@ namespace IEXSharpTest.Cloud.CoreData
 		}
 
 		[Test]
-		[TestCase("BEDU", Period.Annual)]
-		[TestCase("BEDU", Period.Quarter)]
-		[TestCase("F", Period.Annual)]
-		[TestCase("CCM", Period.Quarter)]
-		[TestCase("AAPL", Period.Quarter)]
-		[TestCase("FB", Period.Quarter)]
-		public async Task AdvancedFundamentalsAsyncTest(string symbol, Period period = Period.Quarter)
+		[TestCase("BEDU", TimeSeriesPeriod.Annual)]
+		[TestCase("BEDU", TimeSeriesPeriod.Quarterly)]
+		[TestCase("F", TimeSeriesPeriod.Annual)]
+		[TestCase("CCM", TimeSeriesPeriod.Quarterly)]
+		[TestCase("AAPL", TimeSeriesPeriod.Annual)]
+		[TestCase("AAPL", TimeSeriesPeriod.Quarterly)]
+		[TestCase("FB", TimeSeriesPeriod.Quarterly)]
+		[TestCase("BEDU", TimeSeriesPeriod.Annual, 2)]
+		[TestCase("BEDU", TimeSeriesPeriod.Quarterly, 2)]
+		[TestCase("F", TimeSeriesPeriod.Annual, 3)]
+		[TestCase("CCM", TimeSeriesPeriod.Quarterly, 4)]
+		[TestCase("AAPL", TimeSeriesPeriod.Quarterly, 3)]
+		[TestCase("FB", TimeSeriesPeriod.Quarterly, 5)]
+		[TestCase("AAPL", TimeSeriesPeriod.Quarterly, null, "2008-1-1", "2010-1-1")]
+		public async Task AdvancedFundamentalsAsyncTest(string symbol, TimeSeriesPeriod period = TimeSeriesPeriod.Quarterly, int range = 1, DateTime? from = null, DateTime? to = null)
 		{
-			var response = await sandBoxClient.StockFundamentals.AdvancedFundamentalsAsync(symbol, period);
+			var timeSeries = new TimeSeries(period).AddRange(range).AddDateRange(from, to);
+			var response = await sandBoxClient.StockFundamentals.AdvancedFundamentalsAsync(symbol, period, timeSeries);
 
 			Assert.IsNull(response.ErrorMessage);
 			foreach (var data in response.Data)


### PR DESCRIPTION
Fixed an issue where we send "quarter" instead of "quarterly" in place of the "period" path parameter. Added Timeseries functionality so we can pull data within a date range.  

Added test case to get Advanced fundamentals for the date range.