### PR TITLE
Update from long? to decimal? for previousVolume

### DIFF
--- a/IEXSharp/Model/Shared/Response/Quote.cs
+++ b/IEXSharp/Model/Shared/Response/Quote.cs
@@ -35,7 +35,7 @@ namespace IEXSharp.Model.Shared.Response
 		public decimal? extendedChangePercent { get; set; }
 		public long? extendedPriceTime { get; set; }
 		public decimal? previousClose { get; set; }
-		public long? previousVolume { get; set; }
+		public decimal? previousVolume { get; set; }
 		public decimal? change { get; set; }
 		public decimal? changePercent { get; set; }
 		public decimal? volume { get; set; }

--- a/IEXSharp/Model/Shared/Response/QuoteSSE.cs
+++ b/IEXSharp/Model/Shared/Response/QuoteSSE.cs
@@ -53,7 +53,7 @@ namespace IEXSharp.Model.Shared.Response
 		public decimal? extendedChangePercent { get; set; }
 		public long? extendedPriceTime { get; set; }
 		public decimal? previousClose { get; set; }
-		public long? previousVolume { get; set; }
+		public decimal? previousVolume { get; set; }
 		public decimal? change { get; set; }
 		public decimal? changePercent { get; set; }
 		public long? volume { get; set; }


### PR DESCRIPTION
Examples: $BSE and $HSBCPRA

> System.Text.Json.JsonException: The JSON value could not be converted to System.Nullable`1[System.Int64]. Path: $.previousVolume | LineNumber: 0 | BytePositionInLine: 1181.

<details>
<summary>IEX response</summary>

```json
"BSE": {
  "quote": {
    "avgTotalVolume": 48720,
    "calculationPrice": "previousclose",
    "change": 0,
    "changePercent": 0,
    "close": null,
    "closeSource": "official",
    "closeTime": null,
    "companyName": "BlackRock New York Municipal Income Quality Trust",
    "currency": "USD",
    "delayedPrice": null,
    "delayedPriceTime": null,
    "extendedChange": -0.1147,
    "extendedChangePercent": -0.0077,
    "extendedPrice": 14.79,
    "extendedPriceTime": 1618009200003,
    "high": 14.92,
    "highSource": "15 minute delayed price",
    "highTime": 1617998400374,
    "iexAskPrice": null,
    "iexAskSize": null,
    "iexBidPrice": null,
    "iexBidSize": null,
    "iexClose": 14.79,
    "iexCloseTime": 1617998398188,
    "iexLastUpdated": null,
    "iexMarketPercent": null,
    "iexOpen": 14.77,
    "iexOpenTime": 1617986605328,
    "iexRealtimePrice": null,
    "iexRealtimeSize": null,
    "iexVolume": null,
    "lastTradeTime": 1617998398188,
    "latestPrice": 14.9047,
    "latestSource": "Previous close",
    "latestTime": "April 9, 2021",
    "latestUpdate": 1617940800000,
    "latestVolume": 0,
    "low": 14.711,
    "lowSource": "15 minute delayed price",
    "lowTime": 1617994185033,
    "marketCap": 97173576,
    "oddLotDelayedPrice": 14.76,
    "oddLotDelayedPriceTime": 1617998399998,
    "open": null,
    "openTime": null,
    "openSource": "official",
    "peRatio": null,
    "previousClose": 14.9047,
    "previousVolume": 107311.74540479975,
    "primaryExchange": "NEW YORK STOCK EXCHANGE, INC.",
    "symbol": "BSE",
    "volume": 0,
    "week52High": 14.92,
    "week52Low": 11.4,
    "ytdChange": 0.10437418796015585,
    "isUSMarketOpen": false
  }
}
```
</details>
