### PR TITLE
Fix for int64 deserialisation error in ReportedFinancials

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/ReportedFinancialResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/ReportedFinancialResponse.cs
@@ -7,7 +7,7 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public long DecreaseInUnrecognizedTaxBenefitsIsReasonablyPossible { get; set; }
 		public long? formFiscalYear { get; set; }
 		public string version { get; set; }


### PR DESCRIPTION
When calling StockFundamentals.ReportedFinancialsAsync for AAPL getting an error converting the value 1709268016103.4824 into a int64

IEX response 

``` json
...
"updated":1709268016103.4824
...
```