### PR TITLE
Fix for int64 deserialisation error in AdvancedFundamentals

### DIFF
--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/AdvancedFundamentalsResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/AdvancedFundamentalsResponse.cs
@@ -185,6 +185,6 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
         public string key { get; set; }
         public string subkey { get; set; }
         public long date { get; set; }
-        public long updated { get; set; }
+        public decimal updated { get; set; }
 	}
 }


### PR DESCRIPTION
If I understand all right, the AdvancedFundamentalsResponse does not match the API response in which it needs to convert. I have got the response, and as you can see (at the down), the field "updated" has the type "decimal" in response, but in the class, this field has the type "long". That's why this throws problems with using this request.
Response:
[
    {
        "accountsPayable": 22644107787,
        "accountsPayableTurnover": 1.69811553133182,
        "accountsReceivable": 11773721214,
        "accountsReceivableTurnover": 3.4428452440731,
        "asOfDate": "2022-02-10",
        "assetsCurrentCash": 37430501421,
        " assetsCurrentCashRestricted": 0,
        "assetsCurrentDeferredCompensation": 0,
        "assetsCurrentDeferredTax": 0,
        "assetsCurrentDiscontinuedOperations": 0,
        "assetsCurrentInvestments": 2244023709,
        "assetsCurrentLeasesOperating": 0,
        "assetsCurrentLo ansNet": 84585598029,
        "assetsCurrentOther": 3442815944,
        "assetsCurrentSeparateAccounts": 0,
        "assetsCurrentUnadjusted": 160266754815,
        "assetsFixed": 98405094080,
        "assetsFixedDeferredCompensation": 0,
        "assetsFixedDeferredTax": 14115903140,
        " assetsFixedDiscontinuedOperations": 0,
        "assetsFixedLeasesOperating": 0,
        "assetsFixedOperatingDiscontinuedOperations": 0,
        "assetsFixedOperatingSubsidiaryUnconsolidated": 4736593244,
        "assetsFixedOreo": 0,
        "assetsFixedOther": 42760541735,
        " assetsFixedUnconsolidated": 0,
        "assetsUnadjusted": 262570762027,
        "capex": -1776631298,
        "capexAcquisition": -14078114795,
        "capexMaintenance": 0,
        "cashConversionCycle": -3.16567813118029,
        "cashFlowFinancing": -8321217764,
        "cashFlowInvesting": -2350056513,
        "cashFlowOperating": 3585305270,
        "cashFlowShareRepurchase": 0,
        "cashLongTerm": 0,
        "cashOperating": 11251263216,
        "cashPaidForIncomeTaxes": 584436316,
        "cashPaidForInterest": 1976705398,
        "cashRestricted": 0,
        "chargeAfterTax": -904 5801,
        "chargeAfterTaxDiscontinuedOperations": 0,
        "chargesAfterTaxOther": 0,
        "cik": "38875",
        "creditLossProvision": 0,
        "dataGenerationDate": "2022-02-10",
        "daysInAccountsPayable": 55.4113022781698,
        "daysInInventory": 29.148094456358,
        "daysIn RevenueDeferred": 5.79876630410915,
        "daysRevenueOutstanding": 28.2780693280132,
        "debtFinancial": 118338687058,
        "debtShortTerm": 3190173621,
        "depreciationAndAmortizationAccumulated": 33020278673,
        "depreciationAndAmortizationCashFlow": 15 57133498,
        "dividendsPreferred": 0,
        "dividendsPreferredRedeemableMandatorily": 0,
        "earningsRetained": 36896540471,
        "ebitReported": 1035962641,
        "ebitdaReported": 2630200514,
        "equityShareholder": 49042396288,
        "equityShareholderOther": 0,
        "equi tyShareholderOtherDeferredCompensation": 0,
        "equityShareholderOtherEquity": 0,
        "equityShareholderOtherMezzanine": 0,
        "expenses": 27266228698,
        "expensesAcquisitionMerger": 0,
        "expensesCompensation": 0,
        "expensesDepreciationAndAmortization ": 0,
        "expensesDerivative": 0,
        "expensesDiscontinuedOperations": 0,
        "expensesDiscontinuedOperationsReits": 0,
        "expensesEnergy": 0,
        "expensesForeignCurrency": 0,
        "expensesInterest": 446547581,
        "expensesInterestFinancials": 0,
        "expensesInteres tMinority": -9336594,
        "expensesLegalRegulatoryInsurance": 0,
        "expensesNonOperatingCompanyDefinedOther": -28895024,
        "expensesNonOperatingOther": -3148818595,
        "expensesNonOperatingSubsidiaryUnconsolidated": 0,
        "expensesNonRecurringOther": -9488578797,
        "expensesOperating": 37949165788,
        "expensesOperatingOther": 1341401666,
        "expensesOperatingSubsidiaryUnconsolidated": 0,
        "expensesOreo": 0,
        "expensesOreoReits": 0,
        "expensesOtherFinancing": 1720453017,
        "expensesRestructuring": -14688438,
        "expensesSga": 3279464500,
        "expensesStockCompensation": 0,
        "expensesWriteDown": 0,
        "ffo": 0,
        "figi": "BPGC3B00Q2B0",
        "filingDate": "2022-01-31",
        "filingType": "10-K",
        "fiscalQuarter": 4,
        "fiscalYear": 2030,
        "goodwillAmortizationCash Flow": 0,
        "goodwillAmortizationIncomeStatement": 0,
        "goodwillAndIntangiblesNetOther": 0,
        "goodwillNet": 0,
        "incomeFromOperations": 8663640196,
        "incomeNet": 12760424992,
        "incomeNetPerRevenue": 0.334512807704107,
        "incomeNetPerWabso": 3.16,
        "in comeNetPerWabsoSplitAdjusted": 3.22598524494803,
        "incomeNetPerWabsoSplitAdjustedYoyDeltaPercent": 5.52403321522123,
        "incomeNetPerWadso": 3.08,
        "incomeNetPerWadsoSplitAdjusted": 3.12114480286108,
        "incomeNetPerWadsoSplitAdjustedYoyDelt aPercent": 5.28008345377314,
        "incomeNetPreTax": 11474426182,
        "incomeNetYoyDelta": 15237484610,
        "incomeOperating": 288639367,
        "incomeOperatingDiscontinuedOperations": 0,
        "incomeOperatingOther": 221522508,
        "incomeOperatingSubsidiaryUnconso lidated": 68098046,
        "incomeOperatingSubsidiaryUnconsolidatedAfterTax": 0,
        "incomeTax": -1084539409,
        "incomeTaxCurrent": 730548491,
        "incomeTaxDeferred": -895760544,
        "incomeTaxDiscontinuedOperations": 0,
        "incomeTaxOther": -933298209,
        "income TaxRate": -0.0957738127229446,
        "interestMinority": 106066091,
        "inventory": 12073343834,
        "inventoryTurnover": 3.14431131001149,
        "liabilities": 257218982321,
        "liabilitiesCurrent": 168958820838,
        "liabilitiesNonCurrentAndInterestMinorityTota l": 47736745973,
        "liabilitiesNonCurrentDebt": 17431849970,
        "liabilitiesNonCurrentDeferredCompensation": 0,
        "liabilitiesNonCurrentDeferredTax": 1584066189,
        "liabilitiesNonCurrentDiscontinuedOperations": 0,
        "liabilitiesNonCurrentLeasesOp erating": 1049706917,
        "liabilitiesNonCurrentLongTerm": 26837022697,
        "liabilitiesNonCurrentOperatingDiscontinuedOperations": 0,
        "liabilitiesNonCurrentOther": 27389695688,
        "nibclDeferredCompensation": 0,
        "nibclDeferredTax": 0,
        "nibclDiscon tinuedOperations": 0,
        "nibclLeasesOperating": 356353656,
        "nibclOther": 16770368989,
        "nibclRestructuring": 0,
        "nibclRevenueDeferred": 2449744086,
        "nibclRevenueDeferredTurnover": 16.5762845320131,
        "nibclSeparateAccounts": 0,
        "oci": -874247410 1,
        "periodEndDate": "2021-12-26",
        "ppAndENet": 37865362340,
        "pricePerEarnings": 6.9740451502955,
        "pricePerEarningsPerRevenueYoyDeltaPercent": 1.46708357860348,
        "profitGross": 5539206618,
        "profitGrossPerRevenue": 0.14557908780958,
        "reportD ate": "2022-01-25",
        "researchAndDevelopmentExpense": 0,
        "reserves": 1396171557,
        "reservesInventory": 464317863,
        "reservesLifo": 0,
        "reservesLoanLoss": 962713600,
        "revenue": 37885398546,
        "revenueCostOther": 32838859479,
        "revenueIncomeInterest ": 0,
        "revenueOther": 38740325424,
        "revenueSubsidiaryUnconsolidated": 0,
        "salesCost": 33968072873,
        "sharesIssued": 4135218371,
        "sharesOutstandingPeDateBs": 0,
        "sharesTreasury": 0,
        "stockCommon": 22969981866,
        "stockPreferred": 0,
        "stockPreferre dEquity": 0,
        "stockPreferredMezzanine": 0,
        "stockTreasury": -1633781393,
        "symbol": "F",
        "totalCashFlow": -7077199970,
        "wabso": 4115692855,
        "wabsoSplitAdjusted": 4135987432,
        "wadso": 4165204131,
        "wadsoSplitAdjusted": 4056571445,
        "id": "UASNEDALM NTF",
        "key": "F",
        "subkey": "quarterly",
        "date": 1640908800000,
        "updated": 1709931348415.325
    }
]