### PR TITLE
Fixes JSON value could not be converted to System.Int64 on the 'updated' property

### DIFF
--- a/IEXSharp/Model/CoreData/News/Response/HistoricalNewResponse.cs
+++ b/IEXSharp/Model/CoreData/News/Response/HistoricalNewResponse.cs
@@ -8,6 +8,6 @@ namespace IEXSharp.Model.CoreData.News.Response
 		public string key { get; set; }
 		public string subkey  { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/BalanceSheetResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/BalanceSheetResponse.cs
@@ -44,6 +44,6 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/CoreData/StockFundamentals/Response/CashFlowResponse.cs
+++ b/IEXSharp/Model/CoreData/StockFundamentals/Response/CashFlowResponse.cs
@@ -11,6 +11,6 @@ namespace IEXSharp.Model.CoreData.StockFundamentals.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/CoreData/StockProfiles/Response/InsiderSummaryResponse.cs
+++ b/IEXSharp/Model/CoreData/StockProfiles/Response/InsiderSummaryResponse.cs
@@ -11,6 +11,6 @@ namespace IEXSharp.Model.CoreData.StockProfiles.Response
 		public string id { get; set; }
 		public string key { get; set; }
 		public string subkey { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/CoreData/StockProfiles/Response/InsiderTransactionResponse.cs
+++ b/IEXSharp/Model/CoreData/StockProfiles/Response/InsiderTransactionResponse.cs
@@ -20,7 +20,7 @@ namespace IEXSharp.Model.CoreData.StockProfiles.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public decimal? tranPrice { get; set; }
 		public long? tranShares { get; set; }
 		public decimal? tranValue { get; set; }

--- a/IEXSharp/Model/CoreData/StockResearch/Response/FundOwnershipResponse.cs
+++ b/IEXSharp/Model/CoreData/StockResearch/Response/FundOwnershipResponse.cs
@@ -14,6 +14,6 @@ namespace IEXSharp.Model.CoreData.StockResearch.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/CoreData/StockResearch/Response/InstitutionalOwnershipResponse.cs
+++ b/IEXSharp/Model/CoreData/StockResearch/Response/InstitutionalOwnershipResponse.cs
@@ -11,6 +11,6 @@ namespace IEXSharp.Model.CoreData.StockResearch.Response
 		public string filingDate { get; set; }
 		public long? reportedHolding { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/PremiumData/AuditAnalytics/Response/AccountingQualityAndRiskMatrixResponse.cs
+++ b/IEXSharp/Model/PremiumData/AuditAnalytics/Response/AccountingQualityAndRiskMatrixResponse.cs
@@ -37,6 +37,6 @@ namespace IEXSharp.Model.PremiumData.AuditAnalytics.Response
         public int NonAuditFeesSeverity { get; set; }
         public int AuditFeesOutlierSeverity { get; set; }
         public long Date { get; set; }
-        public long Updated { get; set; }
+        public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/PremiumData/AuditAnalytics/Response/DirectorAndOfficerChangesResponse.cs
+++ b/IEXSharp/Model/PremiumData/AuditAnalytics/Response/DirectorAndOfficerChangesResponse.cs
@@ -55,6 +55,6 @@ namespace IEXSharp.Model.PremiumData.AuditAnalytics.Response
         public string HttpFileNameHtml { get; set; }
         public string HttpFileNameText { get; set; }
         public long Date { get; set; }
-        public long Updated { get; set; }
+        public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/CrossAssetModelOneResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/CrossAssetModelOneResponse.cs
@@ -7,7 +7,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public decimal VolumeComponent { get; set; }
 		public decimal Cam1 { get; set; }
 		public decimal Cam1Slow { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgCpfbComplaintsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgCpfbComplaintsResponse.cs
@@ -19,7 +19,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string TimelyResponse { get; set; }
 		public string ConsumerDisputed { get; set; }
 		public string ComplaintId { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgCpscRecallsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgCpscRecallsResponse.cs
@@ -14,7 +14,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string Title { get; set; }
 		public string ConsumerContact { get; set; }
 		public DateTime LastPublishDate { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgDolVisaApplicationsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgDolVisaApplicationsResponse.cs
@@ -15,7 +15,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public DateTime? DemploymentStartDate { get; set; }
 		public DateTime? DemploymentEndDate { get; set; }
 		public string CaseStatus { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgEpaEnforcementsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgEpaEnforcementsResponse.cs
@@ -31,7 +31,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string VoluntarySelfDisclosureFlag { get; set; }
 		public string MultimediaFlag { get; set; }
 		public string EnfSummaryText { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgEpaMilestonesResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgEpaMilestonesResponse.cs
@@ -13,7 +13,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string CaseNumber { get; set; }
 		public string SubActivityTypeCode { get; set; }
 		public string SubActivityTypeDesc { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgFecIndividualCampaignContributionsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgFecIndividualCampaignContributionsResponse.cs
@@ -11,7 +11,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string TransactionAmt { get; set; }
 		public string TranId { get; set; }
 		public string FileNum { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgOshaInspectionsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgOshaInspectionsResponse.cs
@@ -9,7 +9,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string EstabName { get; set; }
 		public string ActivityNr { get; set; }
 		public string InspType { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgSenateLobbyingResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgSenateLobbyingResponse.cs
@@ -11,7 +11,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string Year { get; set; }
 		public string Received { get; set; }
 		public string Amount { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string TemperatureId { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgUsaSpendingResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgUsaSpendingResponse.cs
@@ -16,7 +16,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string DollarsObligated { get; set; }
 		public DateTime SignedDate { get; set; }
 		public string MajAgencyCat { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgUsptoPatentApplicationsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgUsptoPatentApplicationsResponse.cs
@@ -10,7 +10,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string AppNumber { get; set; }
 		public DateTime DocumentDate { get; set; }
 		public DateTime FilingDate { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgUsptoPatentGrantsResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/EsgUsptoPatentGrantsResponse.cs
@@ -12,7 +12,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public string PatentNumber { get; set; }
 		public DateTime FilingDate { get; set; }
 		public DateTime PublicationDate { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/ExtractAlpha/Response/TacticalModelOneResponse.cs
+++ b/IEXSharp/Model/PremiumData/ExtractAlpha/Response/TacticalModelOneResponse.cs
@@ -9,7 +9,7 @@ namespace IEXSharp.Model.PremiumData.ExtractAlpha.Response
 		public decimal LiquidityShockComponent { get; set; }
 		public decimal SeasonalityComponent { get; set; }
 		public decimal Tm1 { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/FraudFactors/Response/NonTimelyFilingsResponse.cs
+++ b/IEXSharp/Model/PremiumData/FraudFactors/Response/NonTimelyFilingsResponse.cs
@@ -9,7 +9,7 @@ namespace IEXSharp.Model.PremiumData.FraudFactors.Response
 		public string companyName { get; set; }
 		public DateTime filingDate { get; set; }
 		public string filingType { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/FraudFactors/Response/SimiliarityIndexResponse.cs
+++ b/IEXSharp/Model/PremiumData/FraudFactors/Response/SimiliarityIndexResponse.cs
@@ -6,7 +6,7 @@ namespace IEXSharp.Model.PremiumData.FraudFactors.Response
 	{
 		public string symbol { get; set; }
 		public long cik { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public double cosineScore { get; set; }
 		public double jaccardScore { get; set; }
 		public DateTime periodDate { get; set; }

--- a/IEXSharp/Model/PremiumData/Kavout/Response/KavoutResponse.cs
+++ b/IEXSharp/Model/PremiumData/Kavout/Response/KavoutResponse.cs
@@ -17,6 +17,6 @@ namespace IEXSharp.Model.PremiumData.Kavout.Response
 		public decimal ValueScore { get; set; }
 		public decimal MomentumScore { get; set; }
 		public long Date { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/PremiumData/PrecisionAlpha/Response/PriceDynamicsResponse.cs
+++ b/IEXSharp/Model/PremiumData/PrecisionAlpha/Response/PriceDynamicsResponse.cs
@@ -18,6 +18,6 @@ namespace IEXSharp.Model.PremiumData.PrecisionAlpha.Response
 		public decimal MarketResistance { get; set; }
 		public decimal MarketNoise { get; set; }
 		public long Date { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/BoardOfDirectorsMeetingResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/BoardOfDirectorsMeetingResponse.cs
@@ -10,7 +10,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public DateTime announcedate { get; set; }
 		public DateTime startdate { get; set; }
 		public DateTime enddate { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/BuybacksResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/BuybacksResponse.cs
@@ -26,7 +26,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string NewsReferences { get; set; }
 		public string ExternalNotes { get; set; }
 		public string Created { get; set; }
-		public long Updated { get; set; }
+		public decimal updated { get; set; }
 		public string Id { get; set; }
 		public string Source { get; set; }
 		public string Key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/CompanyTravelResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/CompanyTravelResponse.cs
@@ -28,7 +28,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string additionalInfoUrl { get; set; }
 		public string externalNote { get; set; }
 		public string referenceLink { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/FdaAdvisoryCommiteeMeetingsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/FdaAdvisoryCommiteeMeetingsResponse.cs
@@ -22,7 +22,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string venuecountryiso { get; set; }
 		public string externalnote { get; set; }
 		public string referencelink { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/FilingsDueDatesResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/FilingsDueDatesResponse.cs
@@ -10,7 +10,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public DateTime filingduedate { get; set; }
 		public string quarter { get; set; }
 		public long fiscalyear { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/FiscalQuarterEndResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/FiscalQuarterEndResponse.cs
@@ -10,7 +10,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public DateTime quarterenddate { get; set; }
 		public string quarter { get; set; }
 		public long fiscalyear { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/HolidaysResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/HolidaysResponse.cs
@@ -11,7 +11,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public object earlyclosetime { get; set; }
 		public string countrycode { get; set; }
 		public string financialcentername { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string symbol { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/IndexChangesResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/IndexChangesResponse.cs
@@ -16,7 +16,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string replaceticker { get; set; }
 		public string replaceisin { get; set; }
 		public string replacetickername { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/IposResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/IposResponse.cs
@@ -25,7 +25,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string quietperiod { get; set; }
 		public string lockupperiod { get; set; }
 		public double rating { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/LegalActionsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/LegalActionsResponse.cs
@@ -22,7 +22,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public long classperiodend { get; set; }
 		public string prurl { get; set; }
 		public string stage { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/MergersAndAcquisitionsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/MergersAndAcquisitionsResponse.cs
@@ -20,7 +20,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string targetCompanyId { get; set; }
 		public string targetName { get; set; }
 		public string targetSymbol { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/ProductEventsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/ProductEventsResponse.cs
@@ -12,7 +12,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string region { get; set; }
 		public string distributor { get; set; }
 		public string accuracy { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/SameStoreSalesResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/SameStoreSalesResponse.cs
@@ -13,7 +13,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public DateTime samestoresalesdate { get; set; }
 		public string samestoresalesdatestatus { get; set; }
 		public string publicationlink { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/SecondaryOfferingsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/SecondaryOfferingsResponse.cs
@@ -20,7 +20,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string underwritermanager { get; set; }
 		public string prospectuslink { get; set; }
 		public string linktopublication { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/ShareHolderMeetingsResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/ShareHolderMeetingsResponse.cs
@@ -23,7 +23,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string shmdistance { get; set; }
 		public string referencelink { get; set; }
 		public object shmmeetingtype { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonEventResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonEventResponse.cs
@@ -26,7 +26,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
         public object additionalinfourl { get; set; }
         public object externalnote { get; set; }
         public object referencelink { get; set; }
-        public long updated { get; set; }
+        public decimal updated { get; set; }
         public presenters presenters { get; set; }
         public string symbol { get; set; }
         public string id { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WallStreetHorizonResponse.cs
@@ -28,7 +28,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string additionalinfourl { get; set; }
 		public string externalnote { get; set; }
 		public string referencelink { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }
 		public string key { get; set; }

--- a/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WitchingHourResponse.cs
+++ b/IEXSharp/Model/PremiumData/WallStreetHorizon/Response/WitchingHourResponse.cs
@@ -9,7 +9,7 @@ namespace IEXSharp.Model.PremiumData.WallStreetHorizon.Response
 		public string eventday { get; set; }
 		public string eventname { get; set; }
 		public string financialcentername { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 		public string symbol { get; set; }
 		public string id { get; set; }
 		public string source { get; set; }

--- a/IEXSharp/Model/Shared/Response/CashFlow.cs
+++ b/IEXSharp/Model/Shared/Response/CashFlow.cs
@@ -29,6 +29,6 @@ namespace IEXSharp.Model.Shared.Response
         public string filingType { get; set; }
         public int fiscalQuarter { get; set; }
         public int fiscalYear { get; set; }
-        public long updated { get; set; }
+        public decimal updated { get; set; }
     }
 }

--- a/IEXSharp/Model/Shared/Response/Earning.cs
+++ b/IEXSharp/Model/Shared/Response/Earning.cs
@@ -22,6 +22,6 @@ namespace IEXSharp.Model.Shared.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/Shared/Response/Financial.cs
+++ b/IEXSharp/Model/Shared/Response/Financial.cs
@@ -69,6 +69,6 @@ namespace IEXSharp.Model.Shared.Response
         public string id { get; set; }
         public string key { get; set; }
         public string subkey { get; set; }
-        public long updated { get; set; }
+        public decimal updated { get; set; }
 	}
 }

--- a/IEXSharp/Model/Shared/Response/TimeSeriesResponse.cs
+++ b/IEXSharp/Model/Shared/Response/TimeSeriesResponse.cs
@@ -8,6 +8,6 @@ namespace IEXSharp.Model.Shared.Response
 		public string key { get; set; }
 		public string subkey { get; set; }
 		public long date { get; set; }
-		public long updated { get; set; }
+		public decimal updated { get; set; }
 	}
 }


### PR DESCRIPTION
Multiple endpoints have been throwing JSON deserialization errors, then trying to populate the 'updated' property. It is currently a long, but IEX is sending a decimal value. Addressed in #119 and #120, but I just came across a third case #121. 

Error: System.Text.Json: The JSON value could not be converted to System.Int64... Either the JSON value is not in a supported format, or is out of bounds for an Int64.

IEXCloud does not seem to provide documentation on the 'updated' property.

In #119 and #120, the PRs change the 'updated' property from a long to a decimal.

To address issue #121, create consistency and prevent future incidents this PR changes the remaining 'updated' properties from a long to a decimal.