### PR TITLE
Fix InsiderTransactionResponse TransactionShares

### DIFF
--- a/IEXSharp/Model/CoreData/StockProfiles/Response/InsiderTransactionResponse.cs
+++ b/IEXSharp/Model/CoreData/StockProfiles/Response/InsiderTransactionResponse.cs
@@ -8,13 +8,13 @@ namespace IEXSharp.Model.CoreData.StockProfiles.Response
 		public string filingDate { get; set; }
 		public string fullName { get; set; }
 		public bool is10b51 { get; set; }
-		public long? postShares { get; set; }
+		public decimal? postShares { get; set; }
 		public string reportedTitle { get; set; }
 		public string symbol { get; set; }
 		public string transactionCode { get; set; }
 		public string transactionDate { get; set; }
 		public decimal? transactionPrice { get; set; }
-		public long? transactionShares { get; set; }
+		public decimal? transactionShares { get; set; }
 		public decimal? transactionValue { get; set; }
 		public string id { get; set; }
 		public string key { get; set; }
@@ -22,7 +22,7 @@ namespace IEXSharp.Model.CoreData.StockProfiles.Response
 		public long date { get; set; }
 		public long updated { get; set; }
 		public decimal? tranPrice { get; set; }
-		public long? tranShares { get; set; }
+		public decimal? tranShares { get; set; }
 		public decimal? tranValue { get; set; }
 	}
 }


### PR DESCRIPTION
InsiderTransactionResponse defines fields TransactionShares, TranShares and PostShares as a nullable long, but IEX sometimes returns it with decimals causing a Json deserialization exception.

Example response from IEX for symbol DIS.
TransactionShares: 595.2000122070312

Exception:
System.Text.Json: The JSON value could not be converted to System.Nullable`1[System.Int64]. Path: $[0].transactionShares | LineNumber: 0 | BytePositionInLine: 321. System.Text.Json.Rethrowable: Either the JSON value is not in a supported format, or is out of bounds for an Int64.

IEX docs define it as type 'number'. 

This PR changes them to nullable decimal to fix #123 
